### PR TITLE
Add memorization dashboard integration

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -37,6 +37,8 @@ import {
   Minus,
   NotebookPen,
   UserCheck,
+  Brain,
+  RefreshCw,
 } from "lucide-react"
 
 export default function DashboardPage() {
@@ -55,6 +57,7 @@ export default function DashboardPage() {
     updateGoalProgress,
     toggleGoalCompletion,
     addGoal,
+    reviewMemorizationTask,
   } = useUser()
 
   const firstName = useMemo(() => profile.name.split(" ")[0] ?? profile.name, [profile.name])
@@ -72,6 +75,12 @@ export default function DashboardPage() {
   const leaderboardData = useMemo(() => dashboard?.leaderboard ?? [], [dashboard?.leaderboard])
   const recitationTasks = useMemo(() => dashboard?.recitationTasks ?? [], [dashboard?.recitationTasks])
   const recitationSessions = useMemo(() => dashboard?.recitationSessions ?? [], [dashboard?.recitationSessions])
+  const memorizationQueue = useMemo(() => dashboard?.memorizationQueue ?? [], [dashboard?.memorizationQueue])
+  const memorizationPlaylists = useMemo(
+    () => dashboard?.memorizationPlaylists ?? [],
+    [dashboard?.memorizationPlaylists],
+  )
+  const memorizationSummary = dashboard?.memorizationSummary
   const dailyTargetCompleted = dailyTarget?.completedAyahs ?? 0
   const dailyTargetGoal = dailyTarget?.targetAyahs ?? 0
   const habitCompletionTarget = dashboard?.habitCompletion.target ?? Math.max(habits.length * 4, 1)
@@ -201,6 +210,36 @@ export default function DashboardPage() {
     ? Math.round(recitationSessions.reduce((total, session) => total + session.accuracy, 0) / recitationSessions.length)
     : 0
 
+  const memorizationDueToday = memorizationSummary?.dueToday ?? 0
+  const memorizationNewCount = memorizationSummary?.newCount ?? 0
+  const memorizationMastered = memorizationSummary?.totalMastered ?? 0
+  const memorizationRecommendedDuration = memorizationSummary?.recommendedDuration ?? 0
+  const memorizationHeatmap = memorizationSummary?.reviewHeatmap ?? []
+
+  const sortedMemorizationQueue = useMemo(() => {
+    return [...memorizationQueue].sort(
+      (a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime(),
+    )
+  }, [memorizationQueue])
+
+  const memorizationDueTasks = useMemo(
+    () =>
+      sortedMemorizationQueue.filter((task) => {
+        const dueDate = new Date(task.dueDate)
+        const today = new Date()
+        dueDate.setHours(0, 0, 0, 0)
+        today.setHours(0, 0, 0, 0)
+        return dueDate.getTime() <= today.getTime()
+      }),
+    [sortedMemorizationQueue],
+  )
+
+  const nextMemorizationTask = memorizationDueTasks[0] ?? sortedMemorizationQueue[0]
+
+  const handleMemorizationReview = (taskId: string) => {
+    reviewMemorizationTask({ taskId, quality: 4, accuracy: 95, durationSeconds: 180 })
+  }
+
   const recitationStatusStyles: Record<string, string> = {
     assigned: "bg-amber-100 text-amber-700",
     submitted: "bg-blue-100 text-blue-700",
@@ -212,6 +251,15 @@ export default function DashboardPage() {
     submitted: "Submitted",
     reviewed: "Reviewed",
   }
+
+  const memorizationStatusLabels: Record<string, string> = {
+    new: "New",
+    due: "Due",
+    learning: "In Review",
+    mastered: "Mastered",
+  }
+
+  const taskStatusLabel = (status: string) => memorizationStatusLabels[status] ?? status
 
   const teacherMap = useMemo(() => new Map(teachers.map((teacher) => [teacher.id, teacher.name])), [teachers])
 
@@ -699,6 +747,168 @@ export default function DashboardPage() {
                   <Button className="bg-gradient-to-r from-maroon-600 to-maroon-700 text-white border-0" asChild>
                     <Link href="/practice">Open Practice Lab</Link>
                   </Button>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="shadow-lg">
+              <CardHeader>
+                <CardTitle className="text-xl flex items-center gap-2">
+                  <Brain className="w-5 h-5 text-maroon-600" />
+                  Memorization Studio
+                </CardTitle>
+                <CardDescription>Keep the spaced repetition queue healthy and on pace.</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-6">
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                  <div className="rounded-lg border border-rose-100 bg-rose-50/70 p-4">
+                    <p className="text-xs uppercase tracking-wide text-rose-600">Due today</p>
+                    <p className="text-3xl font-bold text-rose-700">{memorizationDueToday}</p>
+                    <p className="text-xs text-rose-600">{memorizationRecommendedDuration} min suggested</p>
+                  </div>
+                  <div className="rounded-lg border border-amber-100 bg-amber-50 p-4">
+                    <p className="text-xs uppercase tracking-wide text-amber-600">New cards</p>
+                    <p className="text-3xl font-bold text-amber-700">{memorizationNewCount}</p>
+                    <p className="text-xs text-amber-600">Introduce gradually for retention</p>
+                  </div>
+                  <div className="rounded-lg border border-emerald-100 bg-emerald-50 p-4">
+                    <p className="text-xs uppercase tracking-wide text-emerald-600">Mastered</p>
+                    <p className="text-3xl font-bold text-emerald-700">{memorizationMastered}</p>
+                    <p className="text-xs text-emerald-600">Confidence-backed mastery</p>
+                  </div>
+                  <div className="hidden md:block rounded-lg border border-blue-100 bg-blue-50 p-4">
+                    <p className="text-xs uppercase tracking-wide text-blue-600">Last review</p>
+                    <p className="text-lg font-semibold text-blue-700">
+                      {memorizationSummary?.lastReviewedOn
+                        ? new Date(memorizationSummary.lastReviewedOn).toLocaleTimeString()
+                        : "Not yet"}
+                    </p>
+                    <p className="text-xs text-blue-600">Streak {memorizationSummary?.streak ?? 0} days</p>
+                  </div>
+                </div>
+
+                {nextMemorizationTask ? (
+                  <div className="rounded-lg border border-maroon-100 bg-cream-50 p-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <p className="text-xs uppercase tracking-wide text-maroon-600">Next focus</p>
+                      <p className="text-sm font-semibold text-maroon-900">
+                        {nextMemorizationTask.surah} • Ayah {nextMemorizationTask.ayahRange}
+                      </p>
+                      <p className="text-xs text-maroon-600">
+                        {memorizationSummary?.focusArea || nextMemorizationTask.notes || "Guided by your instructor"}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-3">
+                      <Badge variant="secondary" className="text-xs bg-white text-maroon-700">
+                        {taskStatusLabel(nextMemorizationTask.status)}
+                      </Badge>
+                      <Button
+                        size="sm"
+                        className="bg-gradient-to-r from-maroon-600 to-maroon-700 text-white border-0"
+                        onClick={() => handleMemorizationReview(nextMemorizationTask.id)}
+                      >
+                        <CheckCircle2 className="w-4 h-4 mr-2" />
+                        Mark Reviewed
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="rounded-lg border border-dashed border-maroon-200 bg-maroon-50/60 p-4 text-sm text-maroon-700">
+                    No memorization tasks in the queue yet. Ask your teacher to assign a playlist to get started.
+                  </div>
+                )}
+
+                <div className="space-y-3">
+                  {sortedMemorizationQueue.slice(0, 4).map((task) => (
+                    <div
+                      key={task.id}
+                      className="rounded-lg border border-maroon-100 bg-white p-4 shadow-sm flex flex-col gap-3 md:flex-row md:items-center md:justify-between"
+                    >
+                      <div className="space-y-1">
+                        <p className="text-sm font-semibold text-maroon-900">
+                          {task.surah} • Ayah {task.ayahRange}
+                        </p>
+                        <div className="text-xs text-gray-600 flex flex-wrap items-center gap-3">
+                          <span>Due {new Date(task.dueDate).toLocaleDateString()}</span>
+                          <span>Interval: {task.interval} day{task.interval === 1 ? "" : "s"}</span>
+                          <span>Confidence {(task.memorizationConfidence * 100).toFixed(0)}%</span>
+                          <span>Teacher: {teacherMap.get(task.teacherId) ?? "Instructor"}</span>
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-3">
+                        <Badge variant="secondary" className="text-xs bg-white text-maroon-700">
+                          {taskStatusLabel(task.status)}
+                        </Badge>
+                        <Button variant="outline" size="sm" onClick={() => handleMemorizationReview(task.id)}>
+                          <RefreshCw className="w-4 h-4 mr-2" /> Review
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                  {sortedMemorizationQueue.length === 0 && (
+                    <div className="rounded-lg border border-dashed border-maroon-200 bg-white/70 p-4 text-center text-sm text-gray-600">
+                      Add ayahs to your memorization playlist to populate this view.
+                    </div>
+                  )}
+                </div>
+
+                <div className="grid gap-3 md:grid-cols-2">
+                  {memorizationPlaylists.slice(0, 2).map((playlist) => (
+                    <div key={playlist.id} className="rounded-lg border border-maroon-100 bg-white p-4">
+                      <div className="flex items-center justify-between mb-2">
+                        <p className="text-sm font-semibold text-maroon-900">{playlist.title}</p>
+                        <Badge variant="secondary" className="text-xs bg-maroon-50 text-maroon-700">
+                          {playlist.progress}%
+                        </Badge>
+                      </div>
+                      <p className="text-xs text-gray-600 mb-2">{playlist.description}</p>
+                      <div className="flex items-center justify-between text-xs text-gray-500">
+                        <span>{playlist.ayahCount} ayahs</span>
+                        <span>{playlist.dueCount} due</span>
+                      </div>
+                    </div>
+                  ))}
+                  {memorizationPlaylists.length === 0 && (
+                    <div className="rounded-lg border border-dashed border-maroon-200 bg-white/70 p-4 text-sm text-gray-600">
+                      Create a memorization playlist to track long-term goals.
+                    </div>
+                  )}
+                </div>
+
+                {memorizationHeatmap.length > 0 && (
+                  <div className="space-y-2">
+                    <p className="text-xs uppercase tracking-wide text-gray-500">Recent review momentum</p>
+                    <div className="flex gap-1 flex-wrap">
+                      {memorizationHeatmap.slice(0, 14).map((entry) => (
+                        <div
+                          key={entry.date}
+                          className={`h-6 w-6 rounded-md flex items-center justify-center text-[10px] font-medium ${
+                            entry.completed === 0
+                              ? "bg-gray-100 text-gray-400"
+                              : entry.completed >= 3
+                                ? "bg-maroon-600 text-white"
+                                : "bg-maroon-200 text-maroon-700"
+                          }`}
+                        >
+                          {entry.completed}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex flex-wrap justify-end gap-3">
+                  <Button variant="outline" asChild>
+                    <Link href="/memorization">Open Memorization Center</Link>
+                  </Button>
+                  {nextMemorizationTask && (
+                    <Button
+                      className="bg-gradient-to-r from-maroon-600 to-maroon-700 text-white border-0"
+                      asChild
+                    >
+                      <Link href={`/memorization?focus=${nextMemorizationTask.id}`}>Start Focus Session</Link>
+                    </Button>
+                  )}
                 </div>
               </CardContent>
             </Card>

--- a/components/user-provider.tsx
+++ b/components/user-provider.tsx
@@ -14,6 +14,7 @@ import {
   completeHabitQuest as persistCompleteHabitQuest,
   logRecitationSession as persistRecitationSession,
   setSubscriptionPlan as persistSubscriptionPlan,
+  reviewMemorizationTask as persistMemorizationReview,
   type GoalRecord,
   type TeacherProfile,
   type StudentDashboardRecord,
@@ -24,6 +25,7 @@ import {
   type CompleteHabitResult as PersistHabitResult,
   type SubscriptionPlan,
   type RecitationSubmissionInput,
+  type MemorizationReviewInput,
 } from "@/lib/data/teacher-database"
 import { getActiveSession } from "@/lib/data/auth"
 
@@ -54,6 +56,7 @@ interface UserContextValue {
   upgradeToPremium: () => void
   downgradeToFree: () => void
   submitRecitationResult: (submission: RecitationSubmissionInput) => void
+  reviewMemorizationTask: (review: MemorizationReviewInput) => void
 }
 
 const perksByPlan: Record<SubscriptionPlan, string[]> = {
@@ -113,6 +116,18 @@ function createFallbackDashboardRecord(studentId: string): StudentDashboardRecor
     premiumBoost: { xpBonus: 0, description: "", isActive: false, availableSessions: 0 },
     recitationTasks: [],
     recitationSessions: [],
+    memorizationQueue: [],
+    memorizationPlaylists: [],
+    memorizationSummary: {
+      dueToday: 0,
+      newCount: 0,
+      totalMastered: 0,
+      streak: 0,
+      recommendedDuration: 0,
+      focusArea: "",
+      lastReviewedOn: null,
+      reviewHeatmap: [],
+    },
   }
 }
 
@@ -296,6 +311,16 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     [applyLearnerState, studentId],
   )
 
+  const reviewMemorizationTask = useCallback(
+    (review: MemorizationReviewInput) => {
+      const state = persistMemorizationReview(studentId, review)
+      if (state) {
+        applyLearnerState(state)
+      }
+    },
+    [applyLearnerState, studentId],
+  )
+
   const upgradeToPremium = useCallback(() => {
     const state = persistSubscriptionPlan(studentId, "premium")
     if (state) {
@@ -335,6 +360,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
       toggleGoalCompletion,
       addGoal,
       submitRecitationResult,
+      reviewMemorizationTask,
       upgradeToPremium,
       downgradeToFree,
     }),
@@ -358,6 +384,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
       toggleGoalCompletion,
       addGoal,
       submitRecitationResult,
+      reviewMemorizationTask,
       upgradeToPremium,
       downgradeToFree,
     ],

--- a/lib/data/teacher-database.ts
+++ b/lib/data/teacher-database.ts
@@ -138,6 +138,62 @@ export interface RecitationSubmissionInput {
   expectedText: string
 }
 
+export type MemorizationTaskStatus = "new" | "due" | "learning" | "mastered"
+
+export interface MemorizationPassageRecord {
+  ayah: number
+  arabic: string
+  translation: string
+}
+
+export interface MemorizationTaskRecord {
+  id: string
+  surah: string
+  ayahRange: string
+  status: MemorizationTaskStatus
+  teacherId: string
+  interval: number
+  repetitions: number
+  easeFactor: number
+  memorizationConfidence: number
+  lastReviewed?: string
+  dueDate: string
+  nextReview: string
+  notes?: string
+  playlistId?: string
+  tags?: string[]
+  passages: MemorizationPassageRecord[]
+}
+
+export interface MemorizationPlaylistRecord {
+  id: string
+  title: string
+  description: string
+  ayahCount: number
+  progress: number
+  dueCount: number
+  lastReviewed: string
+  focus: string
+}
+
+export interface MemorizationSummaryRecord {
+  dueToday: number
+  newCount: number
+  totalMastered: number
+  streak: number
+  recommendedDuration: number
+  focusArea: string
+  lastReviewedOn: string | null
+  reviewHeatmap: { date: string; completed: number }[]
+}
+
+export interface MemorizationReviewInput {
+  taskId: string
+  quality: number
+  accuracy: number
+  durationSeconds: number
+}
+
 export interface LeaderboardEntry {
   id: string
   name: string
@@ -186,6 +242,9 @@ export interface StudentDashboardRecord {
   }
   recitationTasks: RecitationTaskRecord[]
   recitationSessions: RecitationSessionRecord[]
+  memorizationQueue: MemorizationTaskRecord[]
+  memorizationPlaylists: MemorizationPlaylistRecord[]
+  memorizationSummary: MemorizationSummaryRecord
 }
 
 interface LearnerMeta {
@@ -230,6 +289,7 @@ const LEVEL_XP_STEP = 500
 const HABIT_LEVEL_STEP = 120
 const MAX_ACTIVITY_ENTRIES = 50
 const MAX_RECITATION_SESSIONS = 50
+const MAX_MEMORIZATION_HEATMAP = 30
 
 const database: TeacherDatabaseSchema = {
   teachers: [
@@ -657,6 +717,143 @@ database.learners["user_001"] = {
         submittedAt: iso(new Date(now.getTime() - 4 * 24 * 60 * 60 * 1000)),
       },
     ],
+    memorizationQueue: [
+      {
+        id: "mem_task_001",
+        surah: "Al-Mulk",
+        ayahRange: "1-5",
+        status: "due",
+        teacherId: "teacher_002",
+        interval: 3,
+        repetitions: 4,
+        easeFactor: 2.4,
+        memorizationConfidence: 0.78,
+        lastReviewed: iso(new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000)),
+        dueDate: iso(new Date(now.getTime() - 12 * 60 * 60 * 1000)),
+        nextReview: iso(new Date(now.getTime() + 2 * 24 * 60 * 60 * 1000)),
+        notes: "Focus on the transition between ayah 3 and 4.",
+        playlistId: "playlist_mulk",
+        tags: ["madd", "qalqalah"],
+        passages: [
+          {
+            ayah: 1,
+            arabic: "تَبَارَكَ الَّذِي بِيَدِهِ الْمُلْكُ وَهُوَ عَلَى كُلِّ شَيْءٍ قَدِيرٌ",
+            translation: "Blessed is He in whose hand is dominion, and He is over all things competent.",
+          },
+          {
+            ayah: 2,
+            arabic:
+              "الَّذِي خَلَقَ الْمَوْتَ وَالْحَيَاةَ لِيَبْلُوَكُمْ أَيُّكُمْ أَحْسَنُ عَمَلًا وَهُوَ الْعَزِيزُ الْغَفُورُ",
+            translation:
+              "He who created death and life to test you [as to] which of you is best in deed - and He is the Exalted in Might, the Forgiving.",
+          },
+        ],
+      },
+      {
+        id: "mem_task_002",
+        surah: "Al-Mulk",
+        ayahRange: "6-11",
+        status: "learning",
+        teacherId: "teacher_002",
+        interval: 2,
+        repetitions: 2,
+        easeFactor: 2.2,
+        memorizationConfidence: 0.64,
+        lastReviewed: iso(new Date(now.getTime() - 24 * 60 * 60 * 1000)),
+        dueDate: iso(new Date(now.getTime() + 6 * 60 * 60 * 1000)),
+        nextReview: iso(new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000)),
+        notes: "Revisit tajweed of the qalqalah letters.",
+        playlistId: "playlist_mulk",
+        passages: [
+          {
+            ayah: 6,
+            arabic: "وَلِلَّذِينَ كَفَرُوا بِرَبِّهِمْ عَذَابُ جَهَنَّمَ ۖ وَبِئْسَ الْمَصِيرُ",
+            translation: "And for those who disbelieved in their Lord is the punishment of Hell, and wretched is the destination.",
+          },
+          {
+            ayah: 7,
+            arabic: "إِذَا أُلْقُوا فِيهَا سَمِعُوا لَهَا شَهِيقًا وَهِيَ تَفُورُ",
+            translation: "When they are thrown into it, they hear from it a [dreadful] inhaling while it boils up.",
+          },
+        ],
+      },
+      {
+        id: "mem_task_003",
+        surah: "Al-Ikhlas",
+        ayahRange: "1-4",
+        status: "mastered",
+        teacherId: "teacher_001",
+        interval: 14,
+        repetitions: 6,
+        easeFactor: 2.6,
+        memorizationConfidence: 0.94,
+        lastReviewed: iso(new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000)),
+        dueDate: iso(new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)),
+        nextReview: iso(new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000)),
+        notes: "Maintain current retention. Excellent flow.",
+        tags: ["review"],
+        passages: [
+          {
+            ayah: 1,
+            arabic: "قُلْ هُوَ اللَّهُ أَحَدٌ",
+            translation: "Say, He is Allah, [who is] One,",
+          },
+          {
+            ayah: 2,
+            arabic: "اللَّهُ الصَّمَدُ",
+            translation: "Allah, the Eternal Refuge.",
+          },
+          {
+            ayah: 3,
+            arabic: "لَمْ يَلِدْ وَلَمْ يُولَدْ",
+            translation: "He neither begets nor is born,",
+          },
+          {
+            ayah: 4,
+            arabic: "وَلَمْ يَكُن لَّهُ كُفُوًا أَحَدٌ",
+            translation: "Nor is there to Him any equivalent.",
+          },
+        ],
+      },
+    ],
+    memorizationPlaylists: [
+      {
+        id: "playlist_mulk",
+        title: "Surah Al-Mulk Mastery",
+        description: "Daily review loop for Surah Al-Mulk with focus on tajweed precision.",
+        ayahCount: 30,
+        progress: 48,
+        dueCount: 2,
+        lastReviewed: iso(new Date(now.getTime() - 12 * 60 * 60 * 1000)),
+        focus: "Long vowels and qalqalah",
+      },
+      {
+        id: "playlist_juz30",
+        title: "Juz Amma Refresh",
+        description: "Weekly consolidation set covering the final Juz.",
+        ayahCount: 564,
+        progress: 72,
+        dueCount: 5,
+        lastReviewed: iso(new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000)),
+        focus: "Consistency and flow",
+      },
+    ],
+    memorizationSummary: {
+      dueToday: 3,
+      newCount: 1,
+      totalMastered: 18,
+      streak: 5,
+      recommendedDuration: 20,
+      focusArea: "Prioritise Surah Al-Mulk verses 1-11",
+      lastReviewedOn: iso(new Date(now.getTime() - 12 * 60 * 60 * 1000)),
+      reviewHeatmap: Array.from({ length: 7 }).map((_, index) => {
+        const date = new Date(now.getTime() - index * 24 * 60 * 60 * 1000)
+        return {
+          date: iso(date).slice(0, 10),
+          completed: Math.max(0, 3 - index),
+        }
+      }),
+    },
   },
   meta: {
     lastHabitActivityDate: yesterdayKey,
@@ -724,6 +921,45 @@ function recalculateRecitationAccuracy(record: LearnerRecord) {
   }
   const total = sessions.reduce((sum, session) => sum + session.accuracy, 0)
   record.dashboard.recitationPercentage = Math.round(total / sessions.length)
+}
+
+function recalculateMemorizationSummary(record: LearnerRecord) {
+  const queue = record.dashboard.memorizationQueue
+  const summary = record.dashboard.memorizationSummary
+  const today = new Date()
+  const todayKey = today.toISOString().slice(0, 10)
+
+  const dueToday = queue.filter((task) => {
+    const dueDate = new Date(task.dueDate)
+    return dueDate.setHours(0, 0, 0, 0) <= today.setHours(0, 0, 0, 0)
+  }).length
+
+  const newCount = queue.filter((task) => task.status === "new" || task.repetitions === 0).length
+  const totalMastered = queue.filter((task) => task.status === "mastered").length
+
+  summary.dueToday = dueToday
+  summary.newCount = newCount
+  summary.totalMastered = totalMastered
+  summary.recommendedDuration = queue.length === 0 ? 0 : Math.min(45, Math.max(10, dueToday * 5))
+
+  if (!summary.focusArea) {
+    const focusTask = queue.find((task) => task.status === "due") ?? queue[0]
+    summary.focusArea = focusTask ? `${focusTask.surah} • Ayah ${focusTask.ayahRange}` : ""
+  }
+
+  const existing = summary.reviewHeatmap.find((entry) => entry.date === todayKey)
+  if (!existing) {
+    summary.reviewHeatmap.unshift({ date: todayKey, completed: 0 })
+  }
+  summary.reviewHeatmap = summary.reviewHeatmap
+    .sort((a, b) => (a.date < b.date ? 1 : -1))
+    .slice(0, MAX_MEMORIZATION_HEATMAP)
+
+  const averageConfidence =
+    queue.length === 0
+      ? 0
+      : queue.reduce((total, task) => total + task.memorizationConfidence, 0) / queue.length
+  record.dashboard.memorizationPercentage = Math.round(Math.max(0, Math.min(1, averageConfidence)) * 100)
 }
 
 export function getTeacherProfiles(): TeacherProfile[] {
@@ -1044,6 +1280,101 @@ export function logRecitationSession(
   }
 
   recalculateRecitationAccuracy(record)
+
+  return cloneLearnerState(record)
+}
+
+export function reviewMemorizationTask(
+  studentId: string,
+  review: MemorizationReviewInput,
+): LearnerState | undefined {
+  const record = getLearnerRecord(studentId)
+  if (!record) return undefined
+
+  const task = record.dashboard.memorizationQueue.find((entry) => entry.id === review.taskId)
+  if (!task) {
+    return cloneLearnerState(record)
+  }
+
+  const nowDate = new Date()
+  const todayKey = nowDate.toISOString().slice(0, 10)
+  const summary = record.dashboard.memorizationSummary
+
+  const quality = Math.max(0, Math.min(5, Math.round(review.quality)))
+  const accuracy = Math.max(0, Math.min(100, Math.round(review.accuracy)))
+  const durationSeconds = Math.max(30, Math.round(review.durationSeconds))
+
+  if (quality >= 3) {
+    task.repetitions += 1
+    task.interval = Math.max(
+      1,
+      quality >= 4 ? Math.round(task.interval * task.easeFactor) : Math.round(task.interval * 1.2),
+    )
+    task.easeFactor = Math.max(1.3, Math.min(2.7, task.easeFactor + (quality - 3) * 0.05))
+  } else {
+    task.interval = 1
+    task.easeFactor = Math.max(1.3, task.easeFactor - 0.15)
+  }
+
+  const confidenceTarget = accuracy / 100
+  task.memorizationConfidence = Math.max(
+    0,
+    Math.min(1, task.memorizationConfidence + (confidenceTarget - task.memorizationConfidence) * 0.4),
+  )
+
+  task.status = quality >= 4 && accuracy >= 90 ? "mastered" : quality >= 3 ? "learning" : "due"
+  if (task.status === "mastered") {
+    task.memorizationConfidence = Math.max(task.memorizationConfidence, 0.9)
+  }
+
+  task.lastReviewed = iso(nowDate)
+  const nextReviewDate = new Date(nowDate.getTime() + task.interval * 24 * 60 * 60 * 1000)
+  task.dueDate = iso(nextReviewDate)
+  task.nextReview = task.dueDate
+
+  const heatmapEntry = summary.reviewHeatmap.find((entry) => entry.date === todayKey)
+  if (heatmapEntry) {
+    heatmapEntry.completed += 1
+  } else {
+    summary.reviewHeatmap.unshift({ date: todayKey, completed: 1 })
+  }
+  summary.reviewHeatmap = summary.reviewHeatmap.slice(0, MAX_MEMORIZATION_HEATMAP)
+
+  if (summary.lastReviewedOn) {
+    const previous = new Date(summary.lastReviewedOn)
+    const diff = getDayDifference(previous.toISOString(), todayKey)
+    if (diff === 1) {
+      summary.streak += 1
+    } else if (diff > 1) {
+      summary.streak = 1
+    }
+  } else {
+    summary.streak = Math.max(summary.streak, 1)
+  }
+  summary.lastReviewedOn = iso(nowDate)
+
+  const hasanatGain = Math.max(10, Math.round((accuracy / 100) * 35))
+  const xpGain = Math.max(15, Math.round((accuracy / 100) * 45))
+  record.stats.hasanat += hasanatGain
+  applyLevelProgression(record.stats, xpGain)
+  record.stats.weeklyXP[nowDate.getDay()] = Math.min(
+    LEVEL_XP_STEP,
+    record.stats.weeklyXP[nowDate.getDay()] + xpGain,
+  )
+  record.stats.studyMinutes += Math.max(1, Math.round(durationSeconds / 60))
+
+  record.dashboard.activities.unshift({
+    id: `activity_${nowDate.getTime()}`,
+    type: "memorization",
+    surah: task.surah,
+    progress: accuracy,
+    timestamp: iso(nowDate),
+  })
+  if (record.dashboard.activities.length > MAX_ACTIVITY_ENTRIES) {
+    record.dashboard.activities = record.dashboard.activities.slice(0, MAX_ACTIVITY_ENTRIES)
+  }
+
+  recalculateMemorizationSummary(record)
 
   return cloneLearnerState(record)
 }


### PR DESCRIPTION
## Summary
- add memorization queue, playlist, and summary records to the teacher database alongside a review handler that updates statistics
- expose memorization review actions through the user provider so UI can trigger persistence
- build a Memorization Studio panel on the student dashboard that surfaces due cards, playlists, and quick actions tied to the data model

## Testing
- `npm run lint` *(fails: existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b98547308327be04a9b9c9177d37