### PR TITLE
Enhance student tajweed panel with teacher-tracked focus data

### DIFF
--- a/components/user-provider.tsx
+++ b/components/user-provider.tsx
@@ -128,6 +128,7 @@ function createFallbackDashboardRecord(studentId: string): StudentDashboardRecor
       lastReviewedOn: null,
       reviewHeatmap: [],
     },
+    tajweedFocus: [],
   }
 }
 


### PR DESCRIPTION
## Summary
- add explicit tajweed focus types, seed data, and logging updates in the teacher database so recitation submissions update tracked focus areas
- extend the user provider fallback dashboard state to include tajweed focus information
- enhance the student dashboard recitation panel with tajweed readiness metrics and detailed focus area cards tied to teacher guidance

## Testing
- `npm run lint` *(fails: existing lint errors throughout the repo unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d4bc34a7948327b5dc1c444d09e8d2