### PR TITLE
Conditionally load Vercel analytics script

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,8 @@ import "./globals.css"
 import { UserProvider } from "@/components/user-provider"
 import { Toaster } from "@/components/ui/toaster"
 
+const isAnalyticsEnabled = Boolean(process.env.NEXT_PUBLIC_VERCEL_ANALYTICS_ID)
+
 export const metadata: Metadata = {
   title: "AlFawz Qur'an Institute - Excellence in Qur'anic Education",
   description:
@@ -40,7 +42,7 @@ export default function RootLayout({
           <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
           <Toaster />
         </UserProvider>
-        <Analytics />
+        {isAnalyticsEnabled ? <Analytics /> : null}
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- only render the Vercel Analytics component when a tracking id is configured to prevent failed script requests

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e7a9e75c83279b7725b068545a7c