### PR TITLE
Add immersive gameplay routes for Habit Quest missions

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -446,19 +446,10 @@ export default function DashboardPage() {
       if (!task || task.status === "completed") {
         return
       }
-      if (task.type === "habit" && task.habitId) {
-        completeHabit(task.habitId)
-        return
-      }
-      if (task.type === "recitation" && task.recitationTaskId) {
-        handleCompleteRecitation(task.recitationTaskId)
-        return
-      }
-      if (task.type === "memorization" && task.memorizationTaskId) {
-        handleMemorizationReview(task.memorizationTaskId)
-      }
+      setIsGameDialogOpen(false)
+      router.push(`/games/${task.id}`)
     },
-    [completeHabit, handleCompleteRecitation, handleMemorizationReview],
+    [router],
   )
 
   useEffect(() => {
@@ -1855,11 +1846,14 @@ export default function DashboardPage() {
                             Reward granted
                           </Badge>
                         ) : task.type === "daily_target" ? (
-                          <Button variant="outline" size="sm" className="bg-white" asChild>
-                            <Link href="/reader">
-                              <Target className="w-4 h-4 mr-2" />
-                              Continue reading
-                            </Link>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="bg-white"
+                            onClick={() => handleGameTaskAction(task)}
+                          >
+                            <Target className="w-4 h-4 mr-2" />
+                            Continue reading
                           </Button>
                         ) : (
                           <Button

--- a/app/games/[taskId]/page.tsx
+++ b/app/games/[taskId]/page.tsx
@@ -1,0 +1,718 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import Link from "next/link"
+import { useParams } from "next/navigation"
+import {
+  ArrowLeft,
+  Award,
+  Brain,
+  CheckCircle2,
+  ChevronRight,
+  Flame,
+  Gamepad2,
+  ListChecks,
+  Mic,
+  NotebookPen,
+  Sparkles,
+  Target,
+  Timer,
+  Trophy,
+} from "lucide-react"
+
+import AppLayout from "@/components/app-layout"
+import { LiveTajweedAnalyzer } from "@/components/live-tajweed-analyzer"
+import { QuranFlipBook } from "@/components/quran-flipbook"
+import { SRSStudySession } from "@/components/srs-study-session"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Progress } from "@/components/ui/progress"
+import { Slider } from "@/components/ui/slider"
+import { Textarea } from "@/components/ui/textarea"
+import { useToast } from "@/hooks/use-toast"
+import { useUser } from "@/hooks/use-user"
+import type {
+  GamificationTaskRecord,
+  GamificationTaskType,
+  MemorizationReviewInput,
+} from "@/lib/data/teacher-database"
+import type { SRSCard } from "@/lib/srs-algorithm"
+
+const FALLBACK_TAJWEED_SESSION = {
+  surah: "Al-Fatiha",
+  ayahRange: "1-3",
+  verses: [
+    {
+      ayah: 1,
+      arabic: "بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ",
+      translation: "In the name of Allah, the Entirely Merciful, the Especially Merciful.",
+    },
+    {
+      ayah: 2,
+      arabic: "الْحَمْدُ لِلَّهِ رَبِّ الْعَالَمِينَ",
+      translation: "All praise is due to Allah, Lord of the worlds.",
+    },
+    {
+      ayah: 3,
+      arabic: "الرَّحْمَٰنِ الرَّحِيمِ",
+      translation: "The Entirely Merciful, the Especially Merciful.",
+    },
+  ],
+} as const
+
+function normalizeTaskId(raw: string | string[] | undefined): string | null {
+  if (!raw) return null
+  return Array.isArray(raw) ? raw[0] ?? null : raw
+}
+
+type HabitQuestGameProps = {
+  task: GamificationTaskRecord
+  onComplete: () => Promise<void>
+  isCompleting: boolean
+  steps: string[]
+  habitTitle: string
+}
+
+function HabitQuestGame({ task, onComplete, isCompleting, steps, habitTitle }: HabitQuestGameProps) {
+  const [completedSteps, setCompletedSteps] = useState<boolean[]>(() => steps.map(() => false))
+  const allStepsComplete = completedSteps.every(Boolean)
+
+  return (
+    <Card className="border-maroon-100 shadow-lg">
+      <CardHeader>
+        <Badge variant="outline" className="bg-maroon-50 text-maroon-700 border-maroon-200 w-fit mb-2">
+          Daily Quest
+        </Badge>
+        <CardTitle className="text-2xl text-maroon-900">{task.title}</CardTitle>
+        <CardDescription className="text-gray-600">
+          Follow the guided routine to complete <span className="font-semibold text-maroon-700">{habitTitle}</span> and earn
+          +{task.xpReward} XP, +{task.hasanatReward} hasanat.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="rounded-lg border border-maroon-100 bg-maroon-50/60 p-4">
+          <h3 className="text-sm font-semibold text-maroon-800 mb-3 flex items-center gap-2">
+            <ListChecks className="h-4 w-4" /> Quest checklist
+          </h3>
+          <div className="space-y-3">
+            {steps.map((step, index) => (
+              <label key={step} className="flex items-start gap-3 text-sm text-maroon-900">
+                <Checkbox
+                  checked={completedSteps[index]}
+                  onCheckedChange={(checked) => {
+                    setCompletedSteps((current) => current.map((value, valueIndex) => (valueIndex === index ? Boolean(checked) : value)))
+                  }}
+                />
+                <span>{step}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="rounded-lg border border-dashed border-maroon-200 bg-white p-4 space-y-3">
+            <h4 className="text-sm font-semibold text-maroon-800 flex items-center gap-2">
+              <NotebookPen className="h-4 w-4" /> Reflection journal
+            </h4>
+            <Textarea placeholder="What did you focus on today?" className="min-h-[120px]" />
+            <p className="text-xs text-gray-500">Your notes stay private to help you improve tomorrow&apos;s quest.</p>
+          </div>
+          <div className="rounded-lg border border-dashed border-maroon-200 bg-white p-4 space-y-4">
+            <div>
+              <p className="text-xs uppercase text-gray-500">Mindful tempo</p>
+              <Slider defaultValue={[70]} min={40} max={120} step={5} className="mt-2" />
+              <p className="text-xs text-gray-500 mt-1">Adjust the slider to keep a consistent, calm pace.</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase text-gray-500">Breath count</p>
+              <Input type="number" min={1} defaultValue={5} className="w-24" />
+              <p className="text-xs text-gray-500 mt-1">Record how many deep breaths you took between ayahs.</p>
+            </div>
+          </div>
+        </div>
+
+        <Button
+          onClick={onComplete}
+          disabled={!allStepsComplete || isCompleting}
+          className="bg-gradient-to-r from-maroon-600 to-maroon-700 text-white border-0"
+        >
+          {isCompleting ? "Granting rewards..." : allStepsComplete ? "Complete quest" : "Finish checklist to complete"}
+        </Button>
+      </CardContent>
+    </Card>
+  )
+}
+
+type RecitationGameProps = {
+  task: GamificationTaskRecord
+  onSubmit: () => Promise<void>
+  isSubmitting: boolean
+  verses: { ayah: number; arabic: string; translation?: string }[]
+  surah: string
+  ayahRange: string
+  targetAccuracy: number
+}
+
+function RecitationBossGame({ task, onSubmit, isSubmitting, verses, surah, ayahRange, targetAccuracy }: RecitationGameProps) {
+  const [practiceNotes, setPracticeNotes] = useState("")
+  const [selfScore, setSelfScore] = useState([targetAccuracy])
+
+  return (
+    <div className="space-y-6">
+      <Card className="border-maroon-100 shadow-lg">
+        <CardHeader>
+          <Badge variant="outline" className="bg-purple-50 text-purple-700 border-purple-200 w-fit mb-2">
+            Boss Battle
+          </Badge>
+          <CardTitle className="text-2xl text-maroon-900">{task.title}</CardTitle>
+          <CardDescription className="text-gray-600">
+            Submit a recitation of <span className="font-semibold text-maroon-700">Surah {surah} ({ayahRange})</span> at {targetAccuracy}%
+            accuracy or higher to claim +{task.xpReward} XP and +{task.hasanatReward} hasanat.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="rounded-lg border border-dashed border-maroon-200 bg-white">
+              <LiveTajweedAnalyzer surah={surah} ayahRange={ayahRange} verses={verses.length > 0 ? verses : FALLBACK_TAJWEED_SESSION.verses} />
+            </div>
+            <div className="rounded-lg border border-dashed border-maroon-200 bg-white p-4 space-y-4">
+              <div>
+                <p className="text-xs uppercase text-gray-500">Self-evaluated accuracy</p>
+                <Slider value={selfScore} onValueChange={setSelfScore} min={70} max={100} step={1} />
+                <p className="text-xs text-gray-500 mt-1">Aim for at least {targetAccuracy}% accuracy to secure full rewards.</p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="practice-notes" className="text-sm text-maroon-800 flex items-center gap-2">
+                  <Mic className="h-4 w-4" /> Practice notes
+                </Label>
+                <Textarea
+                  id="practice-notes"
+                  value={practiceNotes}
+                  onChange={(event) => setPracticeNotes(event.target.value)}
+                  placeholder="Note tajweed rules, tricky transitions, or breath reminders."
+                  className="min-h-[140px]"
+                />
+              </div>
+              <div className="rounded-md bg-maroon-50/60 border border-maroon-100 p-3 text-sm text-maroon-800 space-y-1">
+                <p className="font-semibold flex items-center gap-2">
+                  <Sparkles className="h-4 w-4" /> Boss tips
+                </p>
+                <p>• Warm up with Qalqalah drills.</p>
+                <p>• Maintain a steady tempo, especially across verse transitions.</p>
+                <p>• Highlight makhārij mistakes in your notes to review later.</p>
+              </div>
+            </div>
+          </div>
+
+          <Button
+            onClick={onSubmit}
+            disabled={isSubmitting}
+            className="bg-gradient-to-r from-purple-600 to-maroon-700 text-white border-0"
+          >
+            {isSubmitting ? "Submitting recitation..." : "Submit recitation"}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+type MemorizationGameProps = {
+  task: GamificationTaskRecord
+  cards: SRSCard[]
+  onSessionComplete: (
+    results: { card: SRSCard; result: { quality: number; accuracy: number; responseTime: number; wasCorrect: boolean } }[],
+  ) => void
+  isComplete: boolean
+}
+
+function MemorizationSprintGame({ task, cards, onSessionComplete, isComplete }: MemorizationGameProps) {
+  return (
+    <div className="space-y-6">
+      <Card className="border-maroon-100 shadow-lg">
+        <CardHeader>
+          <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-200 w-fit mb-2">
+            Memory Sprint
+          </Badge>
+          <CardTitle className="text-2xl text-maroon-900">{task.title}</CardTitle>
+          <CardDescription className="text-gray-600">
+            Review your memorization queue to earn +{task.xpReward} XP and +{task.hasanatReward} hasanat.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <SRSStudySession cards={cards} onSessionComplete={onSessionComplete} />
+        </CardContent>
+      </Card>
+      {isComplete && (
+        <Card className="border-emerald-200 bg-emerald-50">
+          <CardContent className="py-6 text-center space-y-2">
+            <CheckCircle2 className="h-10 w-10 text-emerald-600 mx-auto" />
+            <p className="font-semibold text-emerald-700">Review logged! Rewards have been added to your profile.</p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+type DailyTargetGameProps = {
+  task: GamificationTaskRecord
+  completed: number
+  target: number
+  onLogAyah: () => void
+  isLogging: boolean
+}
+
+function DailyTargetGame({ task, completed, target, onLogAyah, isLogging }: DailyTargetGameProps) {
+  const percent = target > 0 ? Math.min(100, Math.round((completed / target) * 100)) : 0
+
+  return (
+    <div className="space-y-6">
+      <Card className="border-maroon-100 shadow-lg">
+        <CardHeader>
+          <Badge variant="outline" className="bg-amber-50 text-amber-700 border-amber-200 w-fit mb-2">
+            Streak Shield
+          </Badge>
+          <CardTitle className="text-2xl text-maroon-900">{task.title}</CardTitle>
+          <CardDescription className="text-gray-600">
+            Reach your daily target to fortify the streak shield and earn +{task.xpReward} XP with +{task.hasanatReward} hasanat.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="rounded-lg border border-maroon-100 bg-white p-4">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <p className="text-sm text-gray-500">Ayahs completed today</p>
+                <p className="text-3xl font-bold text-maroon-800">{completed}</p>
+              </div>
+              <div className="text-right">
+                <p className="text-sm text-gray-500">Daily goal</p>
+                <p className="text-3xl font-bold text-maroon-800">{target}</p>
+              </div>
+            </div>
+            <Progress value={percent} className="h-3 mt-4" />
+            <p className="text-xs text-gray-500 mt-2">Complete {Math.max(target - completed, 0)} more ayahs to secure the streak.</p>
+          </div>
+
+          <div className="rounded-lg border border-dashed border-maroon-200 bg-white p-4">
+            <h3 className="text-sm font-semibold text-maroon-800 mb-3 flex items-center gap-2">
+              <Flame className="h-4 w-4" /> Guided reading session
+            </h3>
+            <QuranFlipBook className="rounded-lg border border-maroon-100" />
+          </div>
+
+          <div className="flex flex-col sm:flex-row sm:items-center gap-3">
+            <Button
+              onClick={onLogAyah}
+              disabled={isLogging}
+              className="bg-gradient-to-r from-amber-500 to-maroon-600 text-white border-0"
+            >
+              {isLogging ? "Updating progress..." : "Log another ayah"}
+            </Button>
+            <p className="text-xs text-gray-500">
+              Each ayah you log immediately contributes to today&apos;s streak shield progress.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function createHabitSteps(task: GamificationTaskRecord, habitTitle: string): string[] {
+  if (task.type !== "habit") return []
+  const normalizedTitle = habitTitle.toLowerCase()
+  if (normalizedTitle.includes("recitation")) {
+    return [
+      "Warm up with three deep breaths while reciting basmala.",
+      "Recite today&apos;s assigned ayahs aloud focusing on tajweed cues.",
+      "Record a quick audio snippet and listen back for clarity.",
+      "Log a reflection about improvements for tomorrow.",
+    ]
+  }
+  if (normalizedTitle.includes("memorization")) {
+    return [
+      "Review the last ayah from memory without looking.",
+      "Listen to a reciter and shadow the articulation.",
+      "Recite independently while tracking mistakes.",
+      "Update your memorization journal with challenges encountered.",
+    ]
+  }
+  return [
+    "Review teacher instructions and set your intention.",
+    "Complete the practical activity for this habit.",
+    "Reflect and note down one improvement for next time.",
+  ]
+}
+
+function buildSrsCards(
+  taskId: string,
+  passages: { ayah: number; arabic: string; translation?: string }[] | undefined,
+  easeFactor: number,
+  interval: number,
+  repetitions: number,
+  confidence: number,
+  dueDate?: string,
+  lastReviewed?: string | null,
+): SRSCard[] {
+  const parsedDueDate = dueDate ? new Date(dueDate) : new Date()
+  const parsedLastReviewed = lastReviewed ? new Date(lastReviewed) : null
+
+  if (!passages || passages.length === 0) {
+    return [
+      {
+        id: `${taskId}_fallback`,
+        userId: "learner",
+        ayahId: `${taskId}_1`,
+        surahId: taskId,
+        content: FALLBACK_TAJWEED_SESSION.verses[0]?.arabic ?? "",
+        easeFactor,
+        interval,
+        repetitions,
+        dueDate: parsedDueDate,
+        lastReviewed: parsedLastReviewed,
+        createdAt: parsedLastReviewed ?? new Date(),
+        difficulty: 3,
+        memorizationConfidence: confidence,
+        reviewHistory: [],
+      },
+    ]
+  }
+
+  return passages.map((passage) => ({
+    id: `${taskId}_${passage.ayah}`,
+    userId: "learner",
+    ayahId: `${taskId}:${passage.ayah}`,
+    surahId: taskId,
+    content: passage.arabic,
+    easeFactor,
+    interval,
+    repetitions,
+    dueDate: parsedDueDate,
+    lastReviewed: parsedLastReviewed,
+    createdAt: parsedLastReviewed ?? new Date(),
+    difficulty: 3,
+    memorizationConfidence: confidence,
+    reviewHistory: [],
+  }))
+}
+
+function GameSummary({
+  task,
+  type,
+}: {
+  task: GamificationTaskRecord
+  type: GamificationTaskType
+}) {
+  return (
+    <Card className="border-maroon-100">
+      <CardHeader className="space-y-2">
+        <Badge variant="outline" className="bg-white text-maroon-700 border-maroon-200 w-fit">
+          Rewards
+        </Badge>
+        <CardTitle className="text-xl text-maroon-900 flex items-center gap-2">
+          <Trophy className="h-5 w-5 text-yellow-500" /> Mission rewards
+        </CardTitle>
+        <CardDescription className="text-gray-600">
+          Complete this {type.replace("_", " ")} quest to earn XP and hasanat boosts.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-2 gap-3">
+          <div className="rounded-lg bg-maroon-50/70 border border-maroon-100 p-3 text-center">
+            <p className="text-xs uppercase text-maroon-700">XP Reward</p>
+            <p className="text-2xl font-bold text-maroon-900">+{task.xpReward}</p>
+          </div>
+          <div className="rounded-lg bg-yellow-50 border border-yellow-100 p-3 text-center">
+            <p className="text-xs uppercase text-yellow-700">Hasanat</p>
+            <p className="text-2xl font-bold text-yellow-600">+{task.hasanatReward}</p>
+          </div>
+        </div>
+        <div className="rounded-lg border border-dashed border-maroon-200 bg-white p-3 text-sm text-gray-600 space-y-2">
+          <p className="font-semibold text-maroon-800 flex items-center gap-2">
+            <Award className="h-4 w-4 text-maroon-600" /> Streak bonus
+          </p>
+          <p>Earn a 1.2x multiplier when you complete all daily quests before Maghrib.</p>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default function GameDetailPage() {
+  const params = useParams()
+  const { toast } = useToast()
+  const taskId = normalizeTaskId(params?.taskId)
+  const {
+    profile,
+    dashboard,
+    habits,
+    completeHabit,
+    completeRecitationAssignment,
+    reviewMemorizationTask,
+    incrementDailyTarget,
+  } = useUser()
+
+  const task = useMemo(() => {
+    if (!taskId) return null
+    return dashboard?.gamePanel.tasks.find((entry) => entry.id === taskId) ?? null
+  }, [dashboard?.gamePanel.tasks, taskId])
+
+  const recitationTask = useMemo(() => {
+    if (!task || !task.recitationTaskId) return null
+    return dashboard?.recitationTasks.find((entry) => entry.id === task.recitationTaskId) ?? null
+  }, [dashboard?.recitationTasks, task])
+
+  const memorizationTask = useMemo(() => {
+    if (!task || !task.memorizationTaskId) return null
+    return dashboard?.memorizationQueue.find((entry) => entry.id === task.memorizationTaskId) ?? null
+  }, [dashboard?.memorizationQueue, task])
+
+  const habit = useMemo(() => {
+    if (!task || !task.habitId) return null
+    return habits.find((entry) => entry.id === task.habitId) ?? null
+  }, [habits, task])
+
+  const [isCompleting, setIsCompleting] = useState(false)
+  const [isSubmittingRecitation, setIsSubmittingRecitation] = useState(false)
+  const [isMemorizationComplete, setIsMemorizationComplete] = useState(false)
+  const [isLoggingAyah, setIsLoggingAyah] = useState(false)
+
+  const handleCompletionToast = (message: string) => {
+    toast({
+      title: "Quest complete",
+      description: message,
+    })
+  }
+
+  const handleHabitCompletion = async () => {
+    if (!task || !task.habitId) return
+    try {
+      setIsCompleting(true)
+      completeHabit(task.habitId)
+      handleCompletionToast("Your habit quest has been logged. XP and hasanat were added to your profile.")
+    } finally {
+      setIsCompleting(false)
+    }
+  }
+
+  const handleRecitationSubmit = async () => {
+    if (!task || !task.recitationTaskId) return
+    try {
+      setIsSubmittingRecitation(true)
+      completeRecitationAssignment(task.recitationTaskId)
+      handleCompletionToast("Recitation submitted successfully. Your teacher will see the update.")
+    } finally {
+      setIsSubmittingRecitation(false)
+    }
+  }
+
+  const handleMemorizationSessionComplete = (
+    results: {
+      card: SRSCard
+      result: { quality: number; accuracy: number; responseTime: number; wasCorrect: boolean }
+    }[],
+  ) => {
+    if (!task || !memorizationTask) return
+    if (results.length === 0) {
+      toast({
+        title: "Session incomplete",
+        description: "Review at least one card to claim rewards.",
+      })
+      return
+    }
+
+    const aggregate = results.reduce(
+      (accumulator, entry) => {
+        return {
+          quality: accumulator.quality + entry.result.quality,
+          accuracy: accumulator.accuracy + entry.result.accuracy,
+          duration: accumulator.duration + entry.result.responseTime,
+        }
+      },
+      { quality: 0, accuracy: 0, duration: 0 },
+    )
+
+    const review: MemorizationReviewInput = {
+      taskId: memorizationTask.id,
+      quality: aggregate.quality / results.length,
+      accuracy: aggregate.accuracy / results.length,
+      durationSeconds: Math.max(60, Math.round(aggregate.duration)),
+    }
+
+    reviewMemorizationTask(review)
+    setIsMemorizationComplete(true)
+    handleCompletionToast("Memorization review logged. Keep up the strong retention!")
+  }
+
+  const handleDailyTargetProgress = () => {
+    if (!task) return
+    try {
+      setIsLoggingAyah(true)
+      incrementDailyTarget(1)
+      toast({
+        title: "Progress updated",
+        description: "One ayah added to today&apos;s streak shield progress.",
+      })
+    } finally {
+      setIsLoggingAyah(false)
+    }
+  }
+
+  if (!task) {
+    return (
+      <AppLayout>
+        <div className="p-6 space-y-6">
+          <Button asChild variant="ghost" className="w-fit">
+            <Link href="/games">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back to quests
+            </Link>
+          </Button>
+          <Card className="border-dashed border-maroon-200 bg-maroon-50/60">
+            <CardContent className="py-12 text-center space-y-3">
+              <Gamepad2 className="h-10 w-10 text-maroon-400 mx-auto" />
+              <p className="font-semibold text-maroon-800">Quest not found</p>
+              <p className="text-sm text-maroon-700">This mission may have expired or been reassigned by your teacher.</p>
+            </CardContent>
+          </Card>
+        </div>
+      </AppLayout>
+    )
+  }
+
+  const questSubtitle = `Mission difficulty: ${task.target} steps • Status: ${task.status.replace("_", " ")}`
+  const dailyTarget = dashboard?.dailyTarget
+
+  let questContent: React.ReactNode = null
+
+  if (task.type === "habit") {
+    const steps = createHabitSteps(task, habit?.title ?? "Habit quest")
+    questContent = (
+      <HabitQuestGame
+        task={task}
+        habitTitle={habit?.title ?? "Daily habit"}
+        steps={steps}
+        onComplete={async () => handleHabitCompletion()}
+        isCompleting={isCompleting}
+      />
+    )
+  } else if (task.type === "recitation") {
+    questContent = (
+      <RecitationBossGame
+        task={task}
+        onSubmit={async () => handleRecitationSubmit()}
+        isSubmitting={isSubmittingRecitation}
+        verses={recitationTask?.verses ?? FALLBACK_TAJWEED_SESSION.verses}
+        surah={recitationTask?.surah ?? FALLBACK_TAJWEED_SESSION.surah}
+        ayahRange={recitationTask?.ayahRange ?? FALLBACK_TAJWEED_SESSION.ayahRange}
+        targetAccuracy={recitationTask?.targetAccuracy ?? 90}
+      />
+    )
+  } else if (task.type === "memorization") {
+    const cards = buildSrsCards(
+      memorizationTask?.id ?? task.id,
+      memorizationTask?.passages,
+      memorizationTask?.easeFactor ?? 2.3,
+      memorizationTask?.interval ?? 1,
+      memorizationTask?.repetitions ?? 0,
+      memorizationTask?.memorizationConfidence ?? 0.6,
+      memorizationTask?.dueDate,
+      memorizationTask?.lastReviewed ?? null,
+    )
+    questContent = (
+      <MemorizationSprintGame
+        task={task}
+        cards={cards}
+        onSessionComplete={handleMemorizationSessionComplete}
+        isComplete={isMemorizationComplete}
+      />
+    )
+  } else {
+    questContent = (
+      <DailyTargetGame
+        task={task}
+        completed={dailyTarget?.completedAyahs ?? 0}
+        target={dailyTarget?.targetAyahs ?? task.target}
+        onLogAyah={handleDailyTargetProgress}
+        isLogging={isLoggingAyah}
+      />
+    )
+  }
+
+  return (
+    <AppLayout>
+      <div className="p-6 space-y-8">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-3">
+            <Button asChild variant="ghost" className="w-fit pl-0">
+              <Link href="/games">
+                <ArrowLeft className="h-4 w-4 mr-2" />
+                Back to Quest Command Center
+              </Link>
+            </Button>
+            <div className="space-y-2">
+              <Badge className="bg-gradient-to-r from-maroon-600 to-maroon-700 text-white border-0 w-fit">
+                Mission {task.type.replace("_", " ").toUpperCase()}
+              </Badge>
+              <h1 className="text-3xl font-bold text-maroon-900">{task.title}</h1>
+              <p className="text-maroon-700">{task.description}</p>
+              <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-gray-500">
+                <Timer className="h-3 w-3" /> {questSubtitle}
+              </div>
+            </div>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Card className="border border-maroon-100">
+              <CardContent className="py-4 px-5">
+                <p className="text-xs uppercase text-gray-500">Learner</p>
+                <p className="text-sm font-semibold text-maroon-900">{profile.name}</p>
+              </CardContent>
+            </Card>
+            <Card className="border border-maroon-100">
+              <CardContent className="py-4 px-5">
+                <p className="text-xs uppercase text-gray-500">Current streak</p>
+                <p className="text-sm font-semibold text-maroon-900">{dashboard?.gamePanel.streak.current ?? 0} days</p>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+          {questContent}
+          <div className="space-y-6">
+            <GameSummary task={task} type={task.type} />
+            <Card className="border-maroon-100">
+              <CardHeader>
+                <CardTitle className="text-lg text-maroon-900 flex items-center gap-2">
+                  <Brain className="h-4 w-4 text-maroon-600" /> Strategy tips
+                </CardTitle>
+                <CardDescription className="text-gray-600">
+                  Use these quick wins to maximize XP and focus in today&apos;s quest.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-gray-600">
+                <div className="flex items-start gap-2">
+                  <ChevronRight className="h-4 w-4 text-maroon-500 mt-0.5" />
+                  Maintain wudhu and posture to elevate your recitation presence.
+                </div>
+                <div className="flex items-start gap-2">
+                  <ChevronRight className="h-4 w-4 text-maroon-500 mt-0.5" />
+                  Record a 30-second clip and listen back for tajweed consistency.
+                </div>
+                <div className="flex items-start gap-2">
+                  <ChevronRight className="h-4 w-4 text-maroon-500 mt-0.5" />
+                  Share a highlight with your teacher to unlock feedback boosts.
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </AppLayout>
+  )
+}

--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -1,0 +1,188 @@
+"use client"
+
+import Link from "next/link"
+import { useMemo } from "react"
+import { Sparkles, Zap, Shield, Target, Gamepad2, Trophy } from "lucide-react"
+
+import AppLayout from "@/components/app-layout"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import { Separator } from "@/components/ui/separator"
+import { useUser } from "@/hooks/use-user"
+
+export default function GamesHubPage() {
+  const { dashboard } = useUser()
+  const gamePanel = dashboard?.gamePanel
+
+  const tasks = useMemo(() => gamePanel?.tasks ?? [], [gamePanel?.tasks])
+  const boosts = useMemo(() => gamePanel?.boosts ?? [], [gamePanel?.boosts])
+
+  return (
+    <AppLayout>
+      <div className="p-6 space-y-8">
+        <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="text-sm uppercase tracking-wider text-maroon-500 font-semibold">Habit Quest Arena</p>
+            <h1 className="text-3xl font-bold text-maroon-900 mt-1">Select your next challenge</h1>
+            <p className="text-maroon-700 mt-2 max-w-2xl">
+              Earn XP, protect your streak shield, and boost your hasanat by completing immersive Qur&apos;anic learning quests.
+              Each mission is crafted by your teachers to strengthen recitation, memorization, and daily discipline.
+            </p>
+          </div>
+          <Badge className="bg-gradient-to-r from-yellow-500 to-orange-500 text-white border-0 px-3 py-2 text-sm flex items-center gap-2">
+            <Gamepad2 className="h-4 w-4" />
+            Season {gamePanel?.season.level ?? 1}
+          </Badge>
+        </header>
+
+        {gamePanel && (
+          <Card className="bg-gradient-to-br from-maroon-600 to-maroon-700 text-white border-0 shadow-xl">
+            <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <CardTitle className="text-xl font-semibold flex items-center gap-2">
+                  <Zap className="h-5 w-5 text-yellow-300" />
+                  Season Progress
+                </CardTitle>
+                <CardDescription className="text-white/80">
+                  {gamePanel.season.name} • Ends {new Date(gamePanel.season.endsOn).toLocaleDateString()}
+                </CardDescription>
+              </div>
+              <div className="flex items-center gap-3 text-sm">
+                <div className="text-right">
+                  <p className="uppercase text-white/60 tracking-wide text-xs">XP</p>
+                  <p className="text-lg font-semibold">{gamePanel.season.xp} / {gamePanel.season.xpToNext}</p>
+                </div>
+                <Progress className="h-2 w-40 bg-white/20" value={Math.min(100, Math.round((gamePanel.season.xp / Math.max(gamePanel.season.xpToNext, 1)) * 100))} />
+              </div>
+            </CardHeader>
+            <CardContent className="grid gap-6 md:grid-cols-3">
+              <div className="rounded-lg bg-white/10 p-4">
+                <p className="text-xs uppercase text-white/70">Streak Shield</p>
+                <p className="text-2xl font-semibold">{gamePanel.streak.current} days</p>
+                <p className="text-sm text-white/70">Best streak {gamePanel.streak.best} days</p>
+              </div>
+              <div className="rounded-lg bg-white/10 p-4">
+                <p className="text-xs uppercase text-white/70">Energy</p>
+                <p className="text-2xl font-semibold">{gamePanel.energy.current}/{gamePanel.energy.max}</p>
+                <p className="text-sm text-white/70">Refreshed {new Date(gamePanel.energy.refreshedAt).toLocaleTimeString()}</p>
+              </div>
+              <div className="rounded-lg bg-white/10 p-4 space-y-2">
+                <p className="text-xs uppercase text-white/70">Active boosts</p>
+                {boosts.length > 0 ? (
+                  boosts.map((boost) => (
+                    <div
+                      key={boost.id}
+                      className={`rounded-md border px-3 py-2 text-xs ${boost.active ? "bg-emerald-500/20 border-emerald-200 text-emerald-100" : "bg-white/10 border-white/20 text-white/70"}`}
+                    >
+                      <p className="font-semibold">{boost.name}</p>
+                      <p>{boost.description}</p>
+                      {boost.expiresAt && <p className="text-[11px] mt-1 text-white/60">Expires {new Date(boost.expiresAt).toLocaleTimeString()}</p>}
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-xs text-white/70">No boosts unlocked yet. Complete quests to earn buffs.</p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        <section className="space-y-4">
+          <div className="flex items-center justify-between flex-wrap gap-3">
+            <h2 className="text-2xl font-semibold text-maroon-900 flex items-center gap-2">
+              <Target className="h-5 w-5 text-maroon-600" /> Active quests
+            </h2>
+            <div className="flex items-center gap-2 text-sm text-gray-600">
+              <Shield className="h-4 w-4 text-green-600" />
+              Rewards refresh daily based on your teacher&apos;s plan.
+            </div>
+          </div>
+          <Separator />
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {tasks.map((task) => {
+              const completionPercent = task.target > 0 ? Math.min(100, Math.round((task.progress / task.target) * 100)) : 0
+              const isCompleted = task.status === "completed"
+
+              return (
+                <Card key={task.id} className="h-full flex flex-col border-maroon-100 shadow-md">
+                  <CardHeader className="space-y-2">
+                    <Badge variant="outline" className="w-fit bg-maroon-50 text-maroon-700 border-maroon-200">
+                      {task.type === "habit" && "Daily Quest"}
+                      {task.type === "recitation" && "Boss Battle"}
+                      {task.type === "memorization" && "Memory Sprint"}
+                      {task.type === "daily_target" && "Streak Shield"}
+                    </Badge>
+                    <CardTitle className="text-xl text-maroon-900">{task.title}</CardTitle>
+                    <CardDescription className="text-gray-600">{task.description}</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-4 flex-1 flex flex-col">
+                    <div>
+                      <div className="flex items-center justify-between text-sm text-gray-600 mb-2">
+                        <span>
+                          {task.progress}/{task.target} steps
+                        </span>
+                        <span>
+                          +{task.xpReward} XP • +{task.hasanatReward} hasanat
+                        </span>
+                      </div>
+                      <Progress value={completionPercent} className="h-2" />
+                    </div>
+                    <div className="mt-auto flex items-center justify-between">
+                      <div className="text-xs text-gray-500">
+                        {isCompleted ? "Reward granted" : "Tap to enter the quest arena"}
+                      </div>
+                      <Button asChild variant={isCompleted ? "secondary" : "default"} className={isCompleted ? "bg-emerald-100 text-emerald-700 border-emerald-200" : "bg-gradient-to-r from-maroon-600 to-maroon-700 text-white border-0"}>
+                        <Link href={`/games/${task.id}`}>
+                          {isCompleted ? "Review quest" : "Continue"}
+                        </Link>
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              )
+            })}
+            {tasks.length === 0 && (
+              <Card className="border-dashed border-maroon-200 bg-maroon-50/60 text-maroon-700">
+                <CardContent className="py-12 text-center space-y-3">
+                  <Sparkles className="h-8 w-8 mx-auto text-maroon-400" />
+                  <p className="font-semibold">No quests available yet</p>
+                  <p className="text-sm text-maroon-600">
+                    Check back soon! Your teachers will unlock new challenges to keep your journey engaging.
+                  </p>
+                </CardContent>
+              </Card>
+            )}
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          <h2 className="text-2xl font-semibold text-maroon-900 flex items-center gap-2">
+            <Trophy className="h-5 w-5 text-yellow-500" /> How to earn max rewards
+          </h2>
+          <div className="grid gap-4 md:grid-cols-3">
+            <Card className="border-maroon-100">
+              <CardHeader>
+                <CardTitle className="text-lg text-maroon-800">Complete daily quests</CardTitle>
+                <CardDescription>Finish all four missions to trigger the 2x XP bonus.</CardDescription>
+              </CardHeader>
+            </Card>
+            <Card className="border-maroon-100">
+              <CardHeader>
+                <CardTitle className="text-lg text-maroon-800">Maintain the streak shield</CardTitle>
+                <CardDescription>Keep your daily target intact to protect bonus multipliers.</CardDescription>
+              </CardHeader>
+            </Card>
+            <Card className="border-maroon-100">
+              <CardHeader>
+                <CardTitle className="text-lg text-maroon-800">Unlock boosts</CardTitle>
+                <CardDescription>Boosts refresh every weekend—redeem them by completing boss battles.</CardDescription>
+              </CardHeader>
+            </Card>
+          </div>
+        </section>
+      </div>
+    </AppLayout>
+  )
+}

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -33,7 +33,7 @@ export default function Navigation() {
 
   const navigation = [
     { name: "Dashboard", href: "/dashboard", icon: Home },
-    { name: "Play Games", href: "/dashboard?playGames=true", icon: Gamepad2 },
+    { name: "Play Games", href: "/games", icon: Gamepad2 },
     { name: "Habit Quest", href: "/habits", icon: Gamepad2 },
     { name: "Qur'an Reader", href: "/reader", icon: BookOpen },
     { name: "Memorization", href: "/memorization", icon: Target },


### PR DESCRIPTION
## Summary
- add a dedicated /games hub that surfaces the current Habit Quest season, boosts, and quest cards
- implement a dynamic quest detail page that powers habit, recitation, memorization, and daily target gameplay flows with interactive UI and reward handling
- update dashboard quest buttons and sidebar navigation to route players into the new gameplay experience

## Testing
- npm run lint *(fails: Cannot find package '@eslint/eslintrc' imported from eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68e46675e9348327a23dd3924ea23cd5