### PR TITLE
Add teacher memorization plan management UI and APIs

### DIFF
--- a/app/api/teacher/classes/route.ts
+++ b/app/api/teacher/classes/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server"
+
+import { getActiveSession } from "@/lib/data/auth"
+import { listClassesForTeacher } from "@/lib/data/teacher-database"
+
+export function GET() {
+  const session = getActiveSession()
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  if (session.role !== "teacher") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const classes = listClassesForTeacher(session.userId).map(({ studentIds, ...rest }) => ({
+    ...rest,
+    studentIds: [...studentIds],
+  }))
+
+  return NextResponse.json({ classes })
+}

--- a/app/api/teacher/plans/[id]/progress/route.ts
+++ b/app/api/teacher/plans/[id]/progress/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server"
+
+import { getActiveSession } from "@/lib/data/auth"
+import { getTeacherPlanProgress } from "@/lib/data/teacher-database"
+
+interface RouteContext {
+  params: { id: string }
+}
+
+export function GET(_request: Request, context: RouteContext) {
+  const session = getActiveSession()
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  if (session.role !== "teacher") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const progress = getTeacherPlanProgress(session.userId, context.params.id)
+  if (!progress) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+
+  return NextResponse.json({
+    progress: {
+      plan: { ...progress.plan, verseKeys: [...progress.plan.verseKeys], classIds: [...progress.plan.classIds] },
+      classes: progress.classes.map((entry) => ({ ...entry })),
+      students: progress.students.map((student) => ({ ...student })),
+    },
+  })
+}

--- a/app/api/teacher/plans/[id]/route.ts
+++ b/app/api/teacher/plans/[id]/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server"
+
+import { getActiveSession } from "@/lib/data/auth"
+import {
+  UpdateTeacherPlanInput,
+  deleteTeacherMemorizationPlan,
+  listTeacherMemorizationPlans,
+  updateTeacherMemorizationPlan,
+} from "@/lib/data/teacher-database"
+
+interface RouteContext {
+  params: { id: string }
+}
+
+function ensureTeacherSession() {
+  const session = getActiveSession()
+  if (!session) {
+    return { error: NextResponse.json({ error: "Unauthorized" }, { status: 401 }) }
+  }
+  if (session.role !== "teacher") {
+    return { error: NextResponse.json({ error: "Forbidden" }, { status: 403 }) }
+  }
+  return { session }
+}
+
+export function GET(_request: Request, context: RouteContext) {
+  const result = ensureTeacherSession()
+  if (result.error) return result.error
+
+  const plan = listTeacherMemorizationPlans(result.session.userId).find(
+    (candidate) => candidate.plan.id === context.params.id,
+  )
+  if (!plan) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 })
+  }
+  return NextResponse.json({
+    plan: {
+      plan: { ...plan.plan, verseKeys: [...plan.plan.verseKeys], classIds: [...plan.plan.classIds] },
+      stats: { ...plan.stats },
+      classes: plan.classes.map(({ studentIds, ...rest }) => ({ ...rest, studentIds: [...studentIds] })),
+    },
+  })
+}
+
+export async function PATCH(request: Request, context: RouteContext) {
+  const result = ensureTeacherSession()
+  if (result.error) return result.error
+
+  let payload: Partial<UpdateTeacherPlanInput>
+  try {
+    payload = (await request.json()) as Partial<UpdateTeacherPlanInput>
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 })
+  }
+
+  const updates: UpdateTeacherPlanInput = {}
+  if (typeof payload.title === "string") {
+    updates.title = payload.title
+  }
+  if (Array.isArray(payload.verseKeys)) {
+    updates.verseKeys = payload.verseKeys.filter((key): key is string => typeof key === "string")
+  }
+  if (Array.isArray(payload.classIds)) {
+    updates.classIds = payload.classIds.filter((id): id is string => typeof id === "string")
+  }
+  if (typeof payload.notes === "string") {
+    updates.notes = payload.notes
+  }
+
+  try {
+    const plan = updateTeacherMemorizationPlan(result.session.userId, context.params.id, updates)
+    return NextResponse.json({ plan })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to update plan"
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}
+
+export function DELETE(_request: Request, context: RouteContext) {
+  const result = ensureTeacherSession()
+  if (result.error) return result.error
+
+  try {
+    const success = deleteTeacherMemorizationPlan(result.session.userId, context.params.id)
+    if (!success) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 })
+    }
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to delete plan"
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+}

--- a/app/api/teacher/plans/route.ts
+++ b/app/api/teacher/plans/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server"
+
+import { getActiveSession } from "@/lib/data/auth"
+import {
+  CreateTeacherPlanInput,
+  createTeacherMemorizationPlan,
+  listTeacherMemorizationPlans,
+} from "@/lib/data/teacher-database"
+
+export function GET() {
+  const session = getActiveSession()
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  if (session.role !== "teacher") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const plans = listTeacherMemorizationPlans(session.userId).map((summary) => ({
+    plan: { ...summary.plan, verseKeys: [...summary.plan.verseKeys], classIds: [...summary.plan.classIds] },
+    stats: { ...summary.stats },
+    classes: summary.classes.map(({ studentIds, ...rest }) => ({ ...rest, studentIds: [...studentIds] })),
+  }))
+
+  return NextResponse.json({ plans })
+}
+
+export async function POST(request: Request) {
+  const session = getActiveSession()
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  if (session.role !== "teacher") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  let payload: Partial<CreateTeacherPlanInput>
+  try {
+    payload = (await request.json()) as Partial<CreateTeacherPlanInput>
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 })
+  }
+
+  if (typeof payload.title !== "string" || !Array.isArray(payload.verseKeys) || !Array.isArray(payload.classIds)) {
+    return NextResponse.json({ error: "Missing required fields" }, { status: 400 })
+  }
+
+  const verseKeys = payload.verseKeys.filter((key): key is string => typeof key === "string")
+  const classIds = payload.classIds.filter((id): id is string => typeof id === "string")
+
+  try {
+    const plan = createTeacherMemorizationPlan(session.userId, {
+      title: payload.title,
+      verseKeys,
+      classIds,
+      notes: typeof payload.notes === "string" ? payload.notes : undefined,
+    })
+    return NextResponse.json({ plan })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to create plan"
+    const status = message.includes("Daily plan creation limit") ? 429 : 400
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/teacher/memorization-plans/PlanManagementClient.tsx
+++ b/app/teacher/memorization-plans/PlanManagementClient.tsx
@@ -1,0 +1,469 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { useToast } from "@/components/ui/use-toast"
+import { PlanCreatorForm } from "@/components/PlanCreatorForm"
+import { PlanProgressModal } from "@/components/PlanProgressModal"
+import { getCachedVerseText } from "@/hooks/useQuranVerses"
+import {
+  SuggestedMemorizationPlan,
+  TeacherClassSummary,
+  TeacherMemorizationPlanSummary,
+} from "@/lib/data/teacher-database"
+import { formatVerseReference } from "@/lib/quran-data"
+import { cn } from "@/lib/utils"
+import { formatDistanceToNow } from "date-fns"
+import {
+  BarChart3,
+  Bell,
+  Copy,
+  FileDown,
+  Loader2,
+  Plus,
+  Trash2,
+  Wand2,
+  Waypoints,
+  BookOpenCheck,
+  Pencil,
+} from "lucide-react"
+
+interface PlanManagementClientProps {
+  teacherId: string
+  initialPlans: TeacherMemorizationPlanSummary[]
+  initialClasses: TeacherClassSummary[]
+  suggestions: SuggestedMemorizationPlan[]
+}
+
+interface DeleteState {
+  planId: string | null
+  isLoading: boolean
+}
+
+export default function PlanManagementClient({
+  teacherId: _teacherId,
+  initialPlans,
+  initialClasses,
+  suggestions,
+}: PlanManagementClientProps) {
+  const [plans, setPlans] = useState<TeacherMemorizationPlanSummary[]>(initialPlans)
+  const [classes] = useState<TeacherClassSummary[]>(initialClasses)
+  const [dialogMode, setDialogMode] = useState<"create" | "edit">("create")
+  const [activePlan, setActivePlan] = useState<TeacherMemorizationPlanSummary | undefined>(undefined)
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+  const [prefillSuggestion, setPrefillSuggestion] = useState<SuggestedMemorizationPlan | null>(null)
+  const [progressPlan, setProgressPlan] = useState<{ id: string; title: string } | null>(null)
+  const [deleteState, setDeleteState] = useState<DeleteState>({ planId: null, isLoading: false })
+  const { toast } = useToast()
+
+  const aggregateStats = useMemo(() => {
+    if (plans.length === 0) {
+      return { plans: 0, verses: 0, students: 0, completionRate: 0 }
+    }
+    const verseTotal = plans.reduce((total, plan) => total + plan.stats.verseCount, 0)
+    const studentTotal = plans.reduce((total, plan) => total + plan.stats.assignedStudents, 0)
+    const completedTotal = plans.reduce((total, plan) => total + plan.stats.completedStudents, 0)
+    const completionRate = studentTotal === 0 ? 0 : Math.round((completedTotal / studentTotal) * 100)
+    return {
+      plans: plans.length,
+      verses: verseTotal,
+      students: studentTotal,
+      completionRate,
+    }
+  }, [plans])
+
+  function openCreateDialog(suggestion?: SuggestedMemorizationPlan) {
+    setDialogMode("create")
+    setActivePlan(undefined)
+    setPrefillSuggestion(suggestion ?? null)
+    setIsDialogOpen(true)
+  }
+
+  function openEditDialog(plan: TeacherMemorizationPlanSummary) {
+    setDialogMode("edit")
+    setActivePlan(plan)
+    setPrefillSuggestion(null)
+    setIsDialogOpen(true)
+  }
+
+  function handlePlanCreated(plan: TeacherMemorizationPlanSummary) {
+    setPlans((previous) => [plan, ...previous.filter((entry) => entry.plan.id !== plan.plan.id)])
+  }
+
+  function handlePlanUpdated(plan: TeacherMemorizationPlanSummary) {
+    setPlans((previous) => previous.map((entry) => (entry.plan.id === plan.plan.id ? plan : entry)))
+  }
+
+  async function handleDuplicate(plan: TeacherMemorizationPlanSummary) {
+    const payload = {
+      title: `${plan.plan.title} (Copy)`,
+      classIds: plan.plan.classIds,
+      verseKeys: plan.plan.verseKeys,
+      notes: plan.plan.notes,
+    }
+    try {
+      const response = await fetch("/api/teacher/plans", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      })
+      const data = (await response.json().catch(() => null)) as
+        | { plan?: TeacherMemorizationPlanSummary; error?: string }
+        | null
+      if (!response.ok || !data?.plan) {
+        throw new Error(data?.error ?? "Unable to duplicate plan")
+      }
+      setPlans((previous) => [data.plan!, ...previous])
+      toast({ title: "Plan duplicated", description: "A copy has been created for your next cycle." })
+    } catch (error) {
+      toast({
+        title: "Could not duplicate plan",
+        description: error instanceof Error ? error.message : "An unexpected error occurred.",
+        variant: "destructive",
+      })
+    }
+  }
+
+  async function handleDeleteConfirm() {
+    if (!deleteState.planId) return
+    setDeleteState((previous) => ({ ...previous, isLoading: true }))
+    try {
+      const response = await fetch(`/api/teacher/plans/${deleteState.planId}`, { method: "DELETE" })
+      const data = (await response.json().catch(() => null)) as { success?: boolean; error?: string } | null
+      if (!response.ok || !data?.success) {
+        throw new Error(data?.error ?? "Unable to delete plan")
+      }
+      setPlans((previous) => previous.filter((entry) => entry.plan.id !== deleteState.planId))
+      toast({
+        title: "Plan deleted",
+        description: "Students will no longer see this memorization plan.",
+      })
+    } catch (error) {
+      toast({
+        title: "Could not delete plan",
+        description: error instanceof Error ? error.message : "An unexpected error occurred.",
+        variant: "destructive",
+      })
+    } finally {
+      setDeleteState({ planId: null, isLoading: false })
+    }
+  }
+
+  function handleExport(plan: TeacherMemorizationPlanSummary) {
+    const verses = plan.plan.verseKeys.map((key) => ({ key, text: getCachedVerseText(key) }))
+    const printable = `<!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charSet="utf-8" />
+          <title>${plan.plan.title} – Memorization Sheet</title>
+          <style>
+            body { font-family: 'Helvetica Neue', Arial, sans-serif; padding: 32px; color: #1f2937; }
+            h1 { margin-bottom: 0; }
+            h2 { color: #047857; margin-top: 32px; }
+            .verse { margin-bottom: 24px; }
+            .reference { font-size: 12px; color: #047857; text-transform: uppercase; }
+            .arabic { font-family: 'Amiri', serif; font-size: 28px; line-height: 1.6; direction: rtl; text-align: right; margin-top: 8px; }
+          </style>
+        </head>
+        <body>
+          <h1>${plan.plan.title}</h1>
+          ${plan.plan.notes ? `<p>${plan.plan.notes}</p>` : ""}
+          <h2>Verses (${verses.length})</h2>
+          ${verses
+            .map(
+              (verse) => `
+              <div class="verse">
+                <div class="reference">${formatVerseReference(verse.key)}</div>
+                <div class="arabic">${verse.text}</div>
+              </div>
+            `,
+            )
+            .join("")}
+        </body>
+      </html>`
+
+    const printWindow = window.open("", "_blank")
+    if (!printWindow) {
+      toast({
+        title: "Export blocked",
+        description: "Allow pop-ups to generate the printable sheet.",
+        variant: "destructive",
+      })
+      return
+    }
+    printWindow.document.write(printable)
+    printWindow.document.close()
+    printWindow.focus()
+    printWindow.print()
+  }
+
+  function handleReminder(plan: TeacherMemorizationPlanSummary) {
+    const awaiting = plan.stats.notStartedStudents + plan.stats.inProgressStudents
+    toast({
+      title: "Gentle reminder drafted",
+      description:
+        awaiting === 0
+          ? "All students are already celebrating this plan!"
+          : `${awaiting} learner${awaiting === 1 ? "" : "s"} still need a nudge. Encourage them with a heartfelt reminder.`,
+    })
+  }
+
+  function closeDialog() {
+    setIsDialogOpen(false)
+    setPrefillSuggestion(null)
+  }
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-4 rounded-3xl border border-emerald-100 bg-gradient-to-br from-white via-emerald-50/60 to-white p-8 shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-semibold text-maroon-900">Memorization plans</h1>
+            <p className="text-sm text-emerald-800">
+              Curate, assign, and celebrate your students’ hifz milestones with clarity and grace.
+            </p>
+          </div>
+          <Button className="bg-emerald-700 text-white hover:bg-emerald-800" onClick={() => openCreateDialog()}>
+            <Plus className="mr-2 h-4 w-4" /> New plan
+          </Button>
+        </div>
+        <div className="grid gap-4 md:grid-cols-4">
+          <Card className="border-emerald-100/70 bg-white/90">
+            <CardContent className="flex flex-col gap-1 p-4">
+              <span className="text-xs uppercase text-emerald-700">Active plans</span>
+              <span className="text-2xl font-semibold text-maroon-900">{aggregateStats.plans}</span>
+            </CardContent>
+          </Card>
+          <Card className="border-emerald-100/70 bg-white/90">
+            <CardContent className="flex flex-col gap-1 p-4">
+              <span className="text-xs uppercase text-emerald-700">Verses assigned</span>
+              <span className="text-2xl font-semibold text-maroon-900">{aggregateStats.verses}</span>
+            </CardContent>
+          </Card>
+          <Card className="border-emerald-100/70 bg-white/90">
+            <CardContent className="flex flex-col gap-1 p-4">
+              <span className="text-xs uppercase text-emerald-700">Learners reached</span>
+              <span className="text-2xl font-semibold text-maroon-900">{aggregateStats.students}</span>
+            </CardContent>
+          </Card>
+          <Card className="border-emerald-100/70 bg-white/90">
+            <CardContent className="flex flex-col gap-1 p-4">
+              <span className="text-xs uppercase text-emerald-700">Average completion</span>
+              <span className="text-2xl font-semibold text-maroon-900">{aggregateStats.completionRate}%</span>
+            </CardContent>
+          </Card>
+        </div>
+      </header>
+
+      {suggestions.length > 0 && (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 text-sm font-medium text-emerald-800">
+            <Wand2 className="h-4 w-4" /> Inspired sequences for your classes
+          </div>
+          <div className="grid gap-4 md:grid-cols-3">
+            {suggestions.map((suggestion) => (
+              <Card key={suggestion.id} className="border-emerald-100 bg-white/90">
+                <CardContent className="flex h-full flex-col gap-3 p-4">
+                  <div>
+                    <h3 className="text-base font-semibold text-maroon-900">{suggestion.title}</h3>
+                    <p className="text-sm text-emerald-700">{suggestion.reason}</p>
+                  </div>
+                  <div className="mt-auto flex items-center justify-between">
+                    <Badge variant="outline" className="border-emerald-200 text-emerald-800">
+                      {suggestion.verseKeys.length} verses
+                    </Badge>
+                    <Button variant="ghost" size="sm" onClick={() => openCreateDialog(suggestion)}>
+                      <BookOpenCheck className="mr-2 h-4 w-4" /> Use plan
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <Card className="border-emerald-100/70 bg-white/95">
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow className="bg-emerald-50/60">
+                <TableHead className="text-emerald-800">Plan</TableHead>
+                <TableHead className="text-emerald-800">Verses</TableHead>
+                <TableHead className="text-emerald-800">Classes</TableHead>
+                <TableHead className="text-emerald-800">Created</TableHead>
+                <TableHead className="text-right text-emerald-800">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {plans.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="py-12 text-center text-sm text-emerald-700">
+                    No memorization plans yet. Create one to begin guiding your class.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                plans.map((plan) => {
+                  const createdAt = new Date(plan.plan.createdAt)
+                  return (
+                    <TableRow key={plan.plan.id} className="align-top">
+                      <TableCell className="space-y-2 py-4">
+                        <div className="flex items-center gap-2 text-maroon-900">
+                          <Waypoints className="h-4 w-4 text-emerald-600" />
+                          <span className="font-medium">{plan.plan.title}</span>
+                        </div>
+                        {plan.plan.notes && <p className="text-xs text-emerald-700">{plan.plan.notes}</p>}
+                        <div className="flex flex-wrap gap-2 text-xs text-emerald-700">
+                          <span>{plan.stats.completedStudents} completed</span>
+                          <span>{plan.stats.inProgressStudents} in progress</span>
+                          <span>{plan.stats.notStartedStudents} not started</span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="py-4">
+                        <Badge variant="outline" className="border-emerald-200 text-emerald-800">
+                          {plan.stats.verseCount} verses
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="py-4">
+                        <div className="flex flex-wrap gap-2">
+                          {plan.classes.map((classRecord) => (
+                            <Badge key={classRecord.id} className="bg-emerald-700/10 text-emerald-800">
+                              {classRecord.name}
+                            </Badge>
+                          ))}
+                        </div>
+                      </TableCell>
+                      <TableCell className="py-4 text-sm text-emerald-700">
+                        {createdAt.toLocaleDateString()}
+                        <div className="text-xs">{formatDistanceToNow(createdAt, { addSuffix: true })}</div>
+                      </TableCell>
+                      <TableCell className="py-4">
+                        <div className="flex flex-wrap justify-end gap-2">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setProgressPlan({ id: plan.plan.id, title: plan.plan.title })}
+                            className="text-emerald-700 hover:bg-emerald-50"
+                          >
+                            <BarChart3 className="mr-1 h-4 w-4" /> Progress
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => openEditDialog(plan)}
+                            className="text-emerald-700 hover:bg-emerald-50"
+                          >
+                            <Pencil className="mr-1 h-4 w-4" /> Edit
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleDuplicate(plan)}
+                            className="text-emerald-700 hover:bg-emerald-50"
+                          >
+                            <Copy className="mr-1 h-4 w-4" /> Duplicate
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleExport(plan)}
+                            className="text-emerald-700 hover:bg-emerald-50"
+                          >
+                            <FileDown className="mr-1 h-4 w-4" /> Export
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleReminder(plan)}
+                            className="text-emerald-700 hover:bg-emerald-50"
+                          >
+                            <Bell className="mr-1 h-4 w-4" /> Reminder
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setDeleteState({ planId: plan.plan.id, isLoading: false })}
+                            className="text-rose-600 hover:bg-rose-50"
+                          >
+                            <Trash2 className="mr-1 h-4 w-4" /> Delete
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  )
+                })
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <Dialog
+        open={isDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            closeDialog()
+          } else {
+            setIsDialogOpen(true)
+          }
+        }}
+      >
+        <DialogContent className="max-w-4xl overflow-y-auto max-h-[90vh]">
+          <PlanCreatorForm
+            key={dialogMode === "edit" ? activePlan?.plan.id ?? "edit" : dialogMode}
+            mode={dialogMode}
+            initialPlan={dialogMode === "edit" ? activePlan : undefined}
+            classes={classes}
+            onCancel={closeDialog}
+            onCreated={(plan) => {
+              handlePlanCreated(plan)
+              closeDialog()
+            }}
+            onUpdated={(plan) => {
+              handlePlanUpdated(plan)
+              closeDialog()
+            }}
+            suggestions={suggestions}
+            prefillSuggestion={dialogMode === "create" ? prefillSuggestion : null}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <PlanProgressModal
+        open={Boolean(progressPlan)}
+        planId={progressPlan?.id ?? null}
+        planTitle={progressPlan?.title}
+        onOpenChange={(open) => {
+          if (!open) setProgressPlan(null)
+        }}
+      />
+
+      <AlertDialog open={Boolean(deleteState.planId)} onOpenChange={(open) => !open && setDeleteState({ planId: null, isLoading: false })}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove this memorization plan?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Students assigned to this plan will no longer see it in their panel. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteState.isLoading}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={deleteState.isLoading}
+              className="bg-rose-600 text-white hover:bg-rose-700"
+              onClick={handleDeleteConfirm}
+            >
+              {deleteState.isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />} Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/app/teacher/memorization-plans/page.tsx
+++ b/app/teacher/memorization-plans/page.tsx
@@ -1,0 +1,35 @@
+import { redirect } from "next/navigation"
+
+import { getActiveSession } from "@/lib/data/auth"
+import {
+  listClassesForTeacher,
+  listTeacherMemorizationPlans,
+  suggestMemorizationPlans,
+} from "@/lib/data/teacher-database"
+
+import PlanManagementClient from "./PlanManagementClient"
+
+export default function TeacherMemorizationPlansPage() {
+  const session = getActiveSession()
+  if (!session) {
+    redirect("/auth/sign-in")
+  }
+  if (session.role !== "teacher") {
+    redirect("/dashboard")
+  }
+
+  const plans = listTeacherMemorizationPlans(session.userId)
+  const classes = listClassesForTeacher(session.userId)
+  const suggestions = suggestMemorizationPlans(session.userId)
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-8 px-4 py-10">
+      <PlanManagementClient
+        teacherId={session.userId}
+        initialPlans={plans}
+        initialClasses={classes}
+        suggestions={suggestions}
+      />
+    </main>
+  )
+}

--- a/components/PlanCreatorForm.tsx
+++ b/components/PlanCreatorForm.tsx
@@ -1,0 +1,631 @@
+"use client"
+
+import { Fragment, useEffect, useMemo, useState } from "react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from "@/components/ui/command"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Separator } from "@/components/ui/separator"
+import { Textarea } from "@/components/ui/textarea"
+import { useToast } from "@/components/ui/use-toast"
+import { useQuranVerses } from "@/hooks/useQuranVerses"
+import {
+  CreateTeacherPlanInput,
+  SuggestedMemorizationPlan,
+  TeacherClassSummary,
+  TeacherMemorizationPlanSummary,
+} from "@/lib/data/teacher-database"
+import { formatVerseReference } from "@/lib/quran-data"
+import {
+  SurahOption,
+  expandVerseRange,
+  getSurahOptions,
+  parseCommaSeparatedVerseKeys,
+  validateVerseKeys,
+  type VerseValidationIssue,
+} from "@/lib/verse-validator"
+import { cn } from "@/lib/utils"
+import { Check, ChevronsUpDown, Loader2, Plus, Sparkles, X } from "lucide-react"
+
+import { VerseSelector, type VerseSelectionBlock } from "./VerseSelector"
+
+interface PlanCreatorFormProps {
+  mode: "create" | "edit"
+  initialPlan?: TeacherMemorizationPlanSummary
+  classes: TeacherClassSummary[]
+  onCancel: () => void
+  onCreated?: (plan: TeacherMemorizationPlanSummary) => void
+  onUpdated?: (plan: TeacherMemorizationPlanSummary) => void
+  suggestions?: SuggestedMemorizationPlan[]
+  prefillSuggestion?: SuggestedMemorizationPlan | null
+}
+
+interface PlanFormState {
+  title: string
+  notes: string
+  blocks: VerseSelectionBlock[]
+  selectedClassIds: string[]
+}
+
+interface VerseSelectionState {
+  verseKeys: string[]
+  blockErrors: Record<string, string | undefined>
+  invalidIssues: VerseValidationIssue[]
+}
+
+interface ClassOption {
+  id: string
+  name: string
+  description?: string
+  studentCount: number
+}
+
+const DEFAULT_BLOCK: VerseSelectionBlock = {
+  id: "block-0",
+  mode: "range",
+  title: "New memorization",
+  surahNumber: undefined,
+  fromAyah: undefined,
+  toAyah: undefined,
+  customVerseKeys: "",
+}
+
+function createBlock(id: string): VerseSelectionBlock {
+  return { ...DEFAULT_BLOCK, id, title: "" }
+}
+
+function createInitialState(
+  mode: PlanCreatorFormProps["mode"],
+  initialPlan?: TeacherMemorizationPlanSummary,
+): PlanFormState {
+  if (mode === "edit" && initialPlan) {
+    const customBlock: VerseSelectionBlock = {
+      id: `block-${initialPlan.plan.id}`,
+      mode: "custom",
+      title: initialPlan.plan.title,
+      customVerseKeys: initialPlan.plan.verseKeys.join(","),
+      surahNumber: undefined,
+      fromAyah: undefined,
+      toAyah: undefined,
+    }
+    return {
+      title: initialPlan.plan.title,
+      notes: initialPlan.plan.notes ?? "",
+      blocks: [customBlock],
+      selectedClassIds: [...initialPlan.plan.classIds],
+    }
+  }
+  return {
+    title: "",
+    notes: "",
+    blocks: [createBlock("block-0")],
+    selectedClassIds: [],
+  }
+}
+
+function buildClassOptions(classes: TeacherClassSummary[]): ClassOption[] {
+  return classes.map((classRecord) => ({
+    id: classRecord.id,
+    name: classRecord.name,
+    description: classRecord.description,
+    studentCount: classRecord.studentCount,
+  }))
+}
+
+function buildVerseSelection(blocks: VerseSelectionBlock[]): VerseSelectionState {
+  const aggregated: { key: string; blockId: string }[] = []
+  const blockErrors: Record<string, string | undefined> = {}
+
+  blocks.forEach((block) => {
+    if (block.mode === "range") {
+      if (!block.surahNumber || !block.fromAyah || !block.toAyah) {
+        blockErrors[block.id] = "Select a surah and ayah range"
+        return
+      }
+      try {
+        const keys = expandVerseRange(block.surahNumber, block.fromAyah, block.toAyah)
+        keys.forEach((key) => aggregated.push({ key, blockId: block.id }))
+      } catch (error) {
+        blockErrors[block.id] = error instanceof Error ? error.message : "Invalid range"
+      }
+    } else {
+      if (!block.customVerseKeys.trim()) {
+        blockErrors[block.id] = "Enter at least one verse key"
+        return
+      }
+      const customKeys = parseCommaSeparatedVerseKeys(block.customVerseKeys)
+      if (customKeys.length === 0) {
+        blockErrors[block.id] = "Enter verse keys in Surah:Ayah format"
+        return
+      }
+      customKeys.forEach((key) => aggregated.push({ key, blockId: block.id }))
+    }
+  })
+
+  const keysForValidation = aggregated.map((entry) => entry.key)
+  const validation = validateVerseKeys(keysForValidation)
+
+  if (validation.issues.length > 0) {
+    const keyToBlocks = new Map<string, Set<string>>()
+    aggregated.forEach((entry) => {
+      const blocksForKey = keyToBlocks.get(entry.key) ?? new Set<string>()
+      blocksForKey.add(entry.blockId)
+      keyToBlocks.set(entry.key, blocksForKey)
+    })
+    validation.issues.forEach((issue) => {
+      const relatedBlocks = keyToBlocks.get(issue.key)
+      relatedBlocks?.forEach((blockId) => {
+        if (!blockErrors[blockId]) {
+          blockErrors[blockId] = `Check verse ${issue.key}: ${issue.reason}`
+        }
+      })
+    })
+  }
+
+  return {
+    verseKeys: validation.validKeys,
+    blockErrors,
+    invalidIssues: validation.issues,
+  }
+}
+
+export function PlanCreatorForm({
+  mode,
+  initialPlan,
+  classes,
+  onCancel,
+  onCreated,
+  onUpdated,
+  suggestions,
+  prefillSuggestion,
+}: PlanCreatorFormProps) {
+  const [formState, setFormState] = useState<PlanFormState>(() => createInitialState(mode, initialPlan))
+  const [availableClasses, setAvailableClasses] = useState<ClassOption[]>(() => buildClassOptions(classes))
+  const [isLoadingClasses, setIsLoadingClasses] = useState(false)
+  const [classPopoverOpen, setClassPopoverOpen] = useState(false)
+  const [submissionError, setSubmissionError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [appliedSuggestionId, setAppliedSuggestionId] = useState<string | null>(null)
+
+  const surahOptions = useMemo<SurahOption[]>(() => getSurahOptions(), [])
+  const { toast } = useToast()
+
+  useEffect(() => {
+    setFormState(createInitialState(mode, initialPlan))
+    setAppliedSuggestionId(null)
+  }, [mode, initialPlan?.plan.id])
+
+  useEffect(() => {
+    setAvailableClasses(buildClassOptions(classes))
+  }, [classes])
+
+  useEffect(() => {
+    let ignore = false
+    async function fetchClasses() {
+      try {
+        setIsLoadingClasses(true)
+        const response = await fetch("/api/teacher/classes")
+        if (!response.ok) {
+          return
+        }
+        const data = (await response.json()) as { classes: TeacherClassSummary[] }
+        if (!ignore && Array.isArray(data.classes)) {
+          setAvailableClasses(buildClassOptions(data.classes))
+        }
+      } finally {
+        if (!ignore) {
+          setIsLoadingClasses(false)
+        }
+      }
+    }
+    fetchClasses()
+    return () => {
+      ignore = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (mode !== "create" || !prefillSuggestion) {
+      return
+    }
+    applySuggestion(prefillSuggestion)
+  }, [prefillSuggestion?.id])
+
+  const verseSelection = useMemo(() => buildVerseSelection(formState.blocks), [formState.blocks])
+  const versePreview = useQuranVerses(verseSelection.verseKeys)
+
+  const totalVerseCount = verseSelection.verseKeys.length
+  const hasBlockingErrors =
+    Object.values(verseSelection.blockErrors).some((message) => Boolean(message)) ||
+    verseSelection.invalidIssues.length > 0
+
+  function updateBlock(id: string, block: VerseSelectionBlock) {
+    setFormState((previous) => ({
+      ...previous,
+      blocks: previous.blocks.map((entry) => (entry.id === id ? block : entry)),
+    }))
+  }
+
+  function addBlock() {
+    const nextId = `block-${Date.now()}`
+    setFormState((previous) => ({
+      ...previous,
+      blocks: [...previous.blocks, createBlock(nextId)],
+    }))
+  }
+
+  function removeBlock(id: string) {
+    setFormState((previous) => ({
+      ...previous,
+      blocks: previous.blocks.length <= 1 ? previous.blocks : previous.blocks.filter((entry) => entry.id !== id),
+    }))
+  }
+
+  function toggleClass(classId: string) {
+    setFormState((previous) => {
+      const exists = previous.selectedClassIds.includes(classId)
+      const nextIds = exists
+        ? previous.selectedClassIds.filter((id) => id !== classId)
+        : [...previous.selectedClassIds, classId]
+      return { ...previous, selectedClassIds: nextIds }
+    })
+  }
+
+  function applySuggestion(suggestion: SuggestedMemorizationPlan) {
+    setFormState((previous) => ({
+      ...previous,
+      title: previous.title || suggestion.title,
+      blocks: [
+        {
+          id: `suggestion-${suggestion.id}`,
+          mode: "custom",
+          title: suggestion.title,
+          customVerseKeys: suggestion.verseKeys.join(","),
+          surahNumber: undefined,
+          fromAyah: undefined,
+          toAyah: undefined,
+        },
+      ],
+    }))
+    setAppliedSuggestionId(suggestion.id)
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setSubmissionError(null)
+
+    if (!formState.title.trim()) {
+      setSubmissionError("Give your plan a heartfelt title before saving.")
+      return
+    }
+    if (formState.selectedClassIds.length === 0) {
+      setSubmissionError("Assign the plan to at least one class.")
+      return
+    }
+    if (verseSelection.verseKeys.length === 0 || hasBlockingErrors) {
+      setSubmissionError("Resolve the verse selection before saving your plan.")
+      return
+    }
+
+    const payload: CreateTeacherPlanInput = {
+      title: formState.title.trim(),
+      classIds: Array.from(new Set(formState.selectedClassIds)),
+      verseKeys: verseSelection.verseKeys,
+      notes: formState.notes.trim() || undefined,
+    }
+
+    setIsSubmitting(true)
+    try {
+      if (mode === "create") {
+        const response = await fetch("/api/teacher/plans", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        })
+        const data = (await response.json().catch(() => null)) as
+          | { plan?: TeacherMemorizationPlanSummary; error?: string }
+          | null
+        if (!response.ok || !data?.plan) {
+          throw new Error(data?.error ?? "Unable to create plan")
+        }
+        onCreated?.(data.plan)
+        toast({
+          title: "Memorization plan created",
+          description: "Your students will now see this plan in their memorization panel.",
+        })
+      } else if (initialPlan) {
+        const response = await fetch(`/api/teacher/plans/${initialPlan.plan.id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        })
+        const data = (await response.json().catch(() => null)) as
+          | { plan?: TeacherMemorizationPlanSummary; error?: string }
+          | null
+        if (!response.ok || !data?.plan) {
+          throw new Error(data?.error ?? "Unable to update plan")
+        }
+        onUpdated?.(data.plan)
+        toast({
+          title: "Memorization plan updated",
+          description: "Students will see the refreshed verses immediately.",
+        })
+      }
+      onCancel()
+    } catch (error) {
+      setSubmissionError(error instanceof Error ? error.message : "Something went wrong")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <Card className="border-emerald-100/70 bg-gradient-to-br from-white to-emerald-50/40">
+        <CardHeader>
+          <CardTitle className="text-xl text-maroon-900">
+            {mode === "create" ? "Craft a new memorization journey" : "Refine memorization plan"}
+          </CardTitle>
+          <CardDescription className="text-emerald-800">
+            Guide your students with intentional sequences rooted in Qur'anic wisdom.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="plan-title">Plan title</Label>
+            <Input
+              id="plan-title"
+              value={formState.title}
+              onChange={(event) => setFormState((previous) => ({ ...previous, title: event.target.value }))}
+              placeholder="e.g., Week 1 • Surah Al-Falaq & An-Nas"
+              className="border-emerald-200/70"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="plan-notes">Teaching intention (optional)</Label>
+            <Textarea
+              id="plan-notes"
+              value={formState.notes}
+              onChange={(event) => setFormState((previous) => ({ ...previous, notes: event.target.value }))}
+              placeholder="Share the focus or heart-goal for this plan."
+              className="border-emerald-200/70"
+              rows={3}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-emerald-100/70 bg-white/80">
+        <CardHeader className="gap-3">
+          <div>
+            <CardTitle className="text-lg text-maroon-900">Step 2 • Select verses</CardTitle>
+            <CardDescription className="text-emerald-800">
+              Choose verses by range or custom keys. Add multiple blocks for sabaq and revision.
+            </CardDescription>
+          </div>
+          {mode === "create" && suggestions && suggestions.length > 0 && (
+            <div className="flex flex-col gap-3 rounded-xl border border-emerald-100 bg-emerald-50/60 p-4">
+              <div className="flex items-center gap-2 text-emerald-900">
+                <Sparkles className="h-4 w-4" />
+                <span className="text-sm font-medium">Suggested plans for your classes</span>
+              </div>
+              <div className="flex flex-wrap gap-3">
+                {suggestions.map((suggestion) => (
+                  <Card
+                    key={suggestion.id}
+                    className={cn(
+                      "w-full max-w-sm border border-emerald-100 bg-white/90",
+                      appliedSuggestionId === suggestion.id && "border-emerald-300",
+                    )}
+                  >
+                    <CardHeader className="pb-2">
+                      <CardTitle className="text-base text-maroon-900">{suggestion.title}</CardTitle>
+                      <CardDescription className="text-emerald-800">{suggestion.reason}</CardDescription>
+                    </CardHeader>
+                    <CardContent className="flex items-center justify-between gap-3 pt-2">
+                      <Badge variant="outline" className="border-emerald-200 text-emerald-800">
+                        {suggestion.verseKeys.length} verses
+                      </Badge>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => applySuggestion(suggestion)}
+                        className="text-emerald-700 hover:bg-emerald-100/60"
+                      >
+                        Apply
+                      </Button>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </div>
+          )}
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="space-y-4">
+            {formState.blocks.map((block, index) => (
+              <VerseSelector
+                key={block.id}
+                index={index}
+                block={block}
+                onChange={(nextBlock) => updateBlock(block.id, nextBlock)}
+                surahOptions={surahOptions}
+                canRemove={formState.blocks.length > 1}
+                onRemove={() => removeBlock(block.id)}
+                error={verseSelection.blockErrors[block.id]}
+              />
+            ))}
+            <Button
+              type="button"
+              variant="outline"
+              onClick={addBlock}
+              className="w-full border-dashed border-emerald-200 text-emerald-800"
+            >
+              <Plus className="mr-2 h-4 w-4" /> Add another block
+            </Button>
+          </div>
+
+          <Separator className="bg-emerald-100" />
+
+          <div className="space-y-4">
+            <div className="flex flex-wrap items-center gap-3 text-sm text-emerald-900">
+              <Badge className="bg-emerald-700 text-white">{totalVerseCount} verse(s)</Badge>
+              <span>{formState.blocks.length} block(s)</span>
+            </div>
+            <div className="rounded-2xl border border-emerald-100 bg-emerald-50/60 p-4">
+              <h3 className="mb-3 text-sm font-medium text-emerald-900">Live verse preview</h3>
+              <ScrollArea className="max-h-72 pr-2">
+                <div className="space-y-4">
+                  {versePreview.verses.length === 0 ? (
+                    <p className="text-sm text-emerald-700">
+                      Select a surah range or enter custom keys to preview the verses here.
+                    </p>
+                  ) : (
+                    versePreview.verses.map((verse, index) => (
+                      <Fragment key={`${verse.key}-${index}`}>
+                        <div className="space-y-2 rounded-xl bg-white/70 p-3 shadow-sm">
+                          <div className="text-xs uppercase text-emerald-700">{formatVerseReference(verse.key)}</div>
+                          <div className="text-2xl leading-[2.2rem] text-maroon-900 font-quran">{verse.text}</div>
+                        </div>
+                      </Fragment>
+                    ))
+                  )}
+                </div>
+              </ScrollArea>
+            </div>
+            {verseSelection.invalidIssues.length > 0 && (
+              <Alert variant="destructive" className="border-rose-200/80 bg-rose-50/80 text-rose-700">
+                <AlertTitle>Check verse references</AlertTitle>
+                <AlertDescription>
+                  Some verse keys could not be validated: {" "}
+                  {Array.from(new Set(verseSelection.invalidIssues.map((issue) => issue.key))).join(", ")}
+                </AlertDescription>
+              </Alert>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-emerald-100/70 bg-white/90">
+        <CardHeader>
+          <CardTitle className="text-lg text-maroon-900">Step 3 • Assign to classes</CardTitle>
+          <CardDescription className="text-emerald-800">
+            Select one or more classes. Students will see the plan instantly in their memorization panel.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Popover open={classPopoverOpen} onOpenChange={setClassPopoverOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full justify-between border-emerald-200/70 text-emerald-900"
+              >
+                <span>
+                  {formState.selectedClassIds.length === 0
+                    ? "Select classes"
+                    : `${formState.selectedClassIds.length} class${formState.selectedClassIds.length === 1 ? "" : "es"} selected`}
+                </span>
+                <ChevronsUpDown className="ml-2 h-4 w-4 opacity-60" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-72 p-0">
+              <Command>
+                <CommandInput placeholder="Search classes" />
+                <CommandEmpty>No classes found.</CommandEmpty>
+                <CommandGroup>
+                  {availableClasses.map((classOption) => {
+                    const isSelected = formState.selectedClassIds.includes(classOption.id)
+                    return (
+                      <CommandItem
+                        key={classOption.id}
+                        value={classOption.name}
+                        onSelect={() => {
+                          toggleClass(classOption.id)
+                        }}
+                      >
+                        <Check className={cn("mr-2 h-4 w-4", isSelected ? "opacity-100" : "opacity-0")} />
+                        <div className="flex flex-col">
+                          <span className="text-sm text-maroon-900">{classOption.name}</span>
+                          <span className="text-xs text-emerald-700">
+                            {classOption.studentCount} learner{classOption.studentCount === 1 ? "" : "s"}
+                          </span>
+                        </div>
+                      </CommandItem>
+                    )
+                  })}
+                </CommandGroup>
+              </Command>
+            </PopoverContent>
+          </Popover>
+
+          {isLoadingClasses && (
+            <div className="flex items-center gap-2 text-sm text-emerald-700">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Syncing your latest class roster…
+            </div>
+          )}
+
+          {availableClasses.length === 0 && (
+            <Alert className="border-emerald-200 bg-emerald-50/70 text-emerald-900">
+              <AlertTitle>No classes yet</AlertTitle>
+              <AlertDescription>
+                Create a class from your teacher dashboard before assigning memorization plans.
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {formState.selectedClassIds.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {formState.selectedClassIds.map((classId) => {
+                const classOption = availableClasses.find((entry) => entry.id === classId)
+                return (
+                  <Badge
+                    key={classId}
+                    variant="secondary"
+                    className="flex items-center gap-1 border border-emerald-200 bg-emerald-50 text-emerald-800"
+                  >
+                    {classOption?.name ?? classId}
+                    <button type="button" onClick={() => toggleClass(classId)} className="ml-1">
+                      <X className="h-3 w-3" />
+                    </button>
+                  </Badge>
+                )
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {submissionError && (
+        <Alert variant="destructive">
+          <AlertTitle>We couldn't save the plan</AlertTitle>
+          <AlertDescription>{submissionError}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="text-sm text-emerald-800">
+          {formState.selectedClassIds.length} class{formState.selectedClassIds.length === 1 ? "" : "es"} •{' '}
+          {totalVerseCount} verse{totalVerseCount === 1 ? "" : "s"}
+        </div>
+        <div className="flex items-center gap-3">
+          <Button type="button" variant="outline" onClick={onCancel} className="border-emerald-200/70">
+            Cancel
+          </Button>
+          <Button type="submit" disabled={isSubmitting} className="bg-emerald-700 text-white hover:bg-emerald-800">
+            {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+            {mode === "create" ? "Save memorization plan" : "Update plan"}
+          </Button>
+        </div>
+      </div>
+    </form>
+  )
+}

--- a/components/PlanProgressModal.tsx
+++ b/components/PlanProgressModal.tsx
@@ -1,0 +1,207 @@
+"use client"
+
+import type React from "react"
+import { useEffect, useMemo, useState } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Progress } from "@/components/ui/progress"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+  TeacherPlanProgress,
+  TeacherPlanProgressClassSummary,
+  TeacherPlanProgressStudent,
+} from "@/lib/data/teacher-database"
+import { formatVerseReference } from "@/lib/quran-data"
+import { cn } from "@/lib/utils"
+import { formatDistanceToNow } from "date-fns"
+import { AlertCircle, CheckCircle2, Clock3, Loader2, PauseCircle } from "lucide-react"
+
+interface PlanProgressModalProps {
+  planId: string | null
+  planTitle?: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+interface FetchState {
+  status: "idle" | "loading" | "success" | "error"
+  error?: string
+  data?: TeacherPlanProgress
+}
+
+const statusConfig: Record<
+  TeacherPlanProgressStudent["status"],
+  { label: string; icon: React.ComponentType<{ className?: string }>; className: string }
+> = {
+  completed: { label: "Completed", icon: CheckCircle2, className: "text-emerald-700" },
+  in_progress: { label: "In progress", icon: Clock3, className: "text-amber-600" },
+  not_started: { label: "Not started", icon: PauseCircle, className: "text-slate-500" },
+}
+
+export function PlanProgressModal({ planId, planTitle, open, onOpenChange }: PlanProgressModalProps) {
+  const [state, setState] = useState<FetchState>({ status: "idle" })
+
+  useEffect(() => {
+    if (!open || !planId) {
+      return
+    }
+    let ignore = false
+    async function fetchProgress() {
+      setState({ status: "loading" })
+      try {
+        const response = await fetch(`/api/teacher/plans/${planId}/progress`)
+        const data = (await response.json().catch(() => null)) as
+          | { progress?: TeacherPlanProgress; error?: string }
+          | null
+        if (ignore) return
+        if (!response.ok || !data?.progress) {
+          throw new Error(data?.error ?? "Unable to load plan progress")
+        }
+        setState({ status: "success", data: data.progress })
+      } catch (error) {
+        if (ignore) return
+        setState({
+          status: "error",
+          error: error instanceof Error ? error.message : "Unable to load plan progress",
+        })
+      }
+    }
+    fetchProgress()
+    return () => {
+      ignore = true
+    }
+  }, [open, planId])
+
+  const classProgress = useMemo(() => {
+    if (state.status !== "success" || !state.data) {
+      return [] as TeacherPlanProgressClassSummary[]
+    }
+    return state.data.classes
+  }, [state])
+
+  const students = state.status === "success" && state.data ? state.data.students : []
+  const verseCount = state.status === "success" && state.data ? state.data.plan.verseKeys.length : 0
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl border-emerald-100 bg-white/95">
+        <DialogHeader>
+          <DialogTitle className="flex items-center justify-between gap-3 text-maroon-900">
+            <span>Plan progress overview</span>
+            {verseCount > 0 && (
+              <Badge className="bg-emerald-700 text-white">{verseCount} verses</Badge>
+            )}
+          </DialogTitle>
+          <DialogDescription className="text-emerald-800">
+            {planTitle ?? "Memorization plan"}
+          </DialogDescription>
+        </DialogHeader>
+
+        {state.status === "loading" && (
+          <div className="flex h-48 flex-col items-center justify-center gap-3 text-emerald-800">
+            <Loader2 className="h-6 w-6 animate-spin" />
+            Fetching student progress…
+          </div>
+        )}
+
+        {state.status === "error" && (
+          <div className="flex h-48 flex-col items-center justify-center gap-3 text-rose-700">
+            <AlertCircle className="h-6 w-6" />
+            {state.error}
+          </div>
+        )}
+
+        {state.status === "success" && state.data && (
+          <div className="space-y-6">
+            <div className="grid gap-4 rounded-2xl border border-emerald-100 bg-emerald-50/70 p-4 md:grid-cols-3">
+              {classProgress.length === 0 ? (
+                <p className="text-sm text-emerald-800">This plan is not assigned to any classes yet.</p>
+              ) : (
+                classProgress.map((classSummary) => {
+                  const total = classSummary.studentCount || 1
+                  const completion = Math.round((classSummary.completed / total) * 100)
+                  const active = classSummary.inProgress
+                  return (
+                    <div key={classSummary.id} className="space-y-2 rounded-xl bg-white/80 p-3 shadow-sm">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <p className="text-sm font-medium text-maroon-900">{classSummary.name}</p>
+                          <p className="text-xs text-emerald-700">
+                            {classSummary.studentCount} learner{classSummary.studentCount === 1 ? "" : "s"}
+                          </p>
+                        </div>
+                        <Badge variant="outline" className="border-emerald-200 text-emerald-800">
+                          {completion}% complete
+                        </Badge>
+                      </div>
+                      <Progress value={completion} className="h-2 bg-emerald-100" />
+                      <div className="flex items-center gap-3 text-xs text-emerald-700">
+                        <span>{classSummary.completed} completed</span>
+                        <span>{active} in progress</span>
+                        <span>{classSummary.notStarted} not started</span>
+                      </div>
+                    </div>
+                  )
+                })
+              )}
+            </div>
+
+            <div className="rounded-2xl border border-emerald-100 bg-white/90">
+              <div className="flex items-center justify-between border-b border-emerald-100 px-4 py-3">
+                <h3 className="text-sm font-medium text-maroon-900">Student progress</h3>
+                <Badge variant="outline" className="border-emerald-200 text-emerald-800">
+                  {students.length} learner{students.length === 1 ? "" : "s"}
+                </Badge>
+              </div>
+              <ScrollArea className="max-h-80">
+                <div className="divide-y divide-emerald-100">
+                  {students.length === 0 ? (
+                    <p className="p-4 text-sm text-emerald-700">No students are assigned to this plan yet.</p>
+                  ) : (
+                    students.map((student) => {
+                      const config = statusConfig[student.status]
+                      const Icon = config.icon
+                      const currentVerse = student.currentVerseIndex < student.verseCount
+                        ? state.data?.plan.verseKeys[student.currentVerseIndex]
+                        : undefined
+                      return (
+                        <div key={student.studentId} className="flex flex-col gap-2 p-4 text-sm">
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <div>
+                              <p className="font-medium text-maroon-900">{student.studentName}</p>
+                              <p className="text-xs text-emerald-700">{student.className}</p>
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <Icon className={cn("h-4 w-4", config.className)} />
+                              <span className={cn("text-xs font-medium", config.className)}>{config.label}</span>
+                            </div>
+                          </div>
+                          <div className="flex flex-wrap items-center gap-3 text-xs text-emerald-700">
+                            <span>
+                              {student.repetitionsDone} / 20 repetitions on current verse
+                            </span>
+                            {currentVerse && (
+                              <span className="rounded-full bg-emerald-50 px-2 py-1">
+                                {formatVerseReference(currentVerse)}
+                              </span>
+                            )}
+                            {student.lastActivity && (
+                              <span>
+                                Last activity {formatDistanceToNow(new Date(student.lastActivity), { addSuffix: true })}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      )
+                    })
+                  )}
+                </div>
+              </ScrollArea>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/VerseSelector.tsx
+++ b/components/VerseSelector.tsx
@@ -1,0 +1,222 @@
+"use client"
+
+import { useMemo } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Textarea } from "@/components/ui/textarea"
+import { SurahOption } from "@/lib/verse-validator"
+import { Minus, Trash2 } from "lucide-react"
+
+export type VerseSelectionMode = "range" | "custom"
+
+export interface VerseSelectionBlock {
+  id: string
+  title?: string
+  mode: VerseSelectionMode
+  surahNumber?: number | null
+  fromAyah?: number | null
+  toAyah?: number | null
+  customVerseKeys: string
+}
+
+interface VerseSelectorProps {
+  index: number
+  block: VerseSelectionBlock
+  onChange: (block: VerseSelectionBlock) => void
+  surahOptions: SurahOption[]
+  canRemove: boolean
+  onRemove?: () => void
+  error?: string
+}
+
+export function VerseSelector({
+  index,
+  block,
+  onChange,
+  surahOptions,
+  canRemove,
+  onRemove,
+  error,
+}: VerseSelectorProps) {
+  const selectedSurah = useMemo(
+    () => surahOptions.find((option) => option.number === block.surahNumber) ?? null,
+    [block.surahNumber, surahOptions],
+  )
+
+  const ayahOptions = useMemo(() => {
+    const count = selectedSurah?.ayahCount ?? 0
+    return Array.from({ length: count }, (_, indexValue) => indexValue + 1)
+  }, [selectedSurah])
+
+  const handleModeChange = (nextMode: VerseSelectionMode) => {
+    if (nextMode === block.mode) {
+      return
+    }
+    onChange({
+      ...block,
+      mode: nextMode,
+      customVerseKeys: nextMode === "custom" ? block.customVerseKeys : "",
+    })
+  }
+
+  const handleSurahChange = (value: string) => {
+    const surahNumber = Number.parseInt(value, 10)
+    if (!Number.isFinite(surahNumber)) {
+      return
+    }
+    onChange({
+      ...block,
+      surahNumber,
+      fromAyah: null,
+      toAyah: null,
+    })
+  }
+
+  const handleFromAyahChange = (value: string) => {
+    const ayah = Number.parseInt(value, 10)
+    if (!Number.isFinite(ayah)) {
+      return
+    }
+    onChange({
+      ...block,
+      fromAyah: ayah,
+      toAyah: block.toAyah ?? ayah,
+    })
+  }
+
+  const handleToAyahChange = (value: string) => {
+    const ayah = Number.parseInt(value, 10)
+    if (!Number.isFinite(ayah)) {
+      return
+    }
+    onChange({
+      ...block,
+      toAyah: ayah,
+    })
+  }
+
+  return (
+    <div className="rounded-2xl border border-emerald-100 bg-white/80 p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <Badge className="bg-emerald-100 text-emerald-800">Block {index + 1}</Badge>
+          <Input
+            placeholder="e.g., Today's sabaq"
+            value={block.title ?? ""}
+            onChange={(event) => onChange({ ...block, title: event.target.value })}
+            className="h-9 max-w-[220px] border-emerald-200/70"
+          />
+        </div>
+        {canRemove ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onRemove}
+            className="text-maroon-600 hover:text-maroon-800"
+          >
+            <Trash2 className="mr-1 h-4 w-4" /> Remove
+          </Button>
+        ) : (
+          <Badge variant="outline" className="border-dashed border-emerald-200 text-emerald-700">
+            <Minus className="mr-1 h-3 w-3" /> Required block
+          </Badge>
+        )}
+      </div>
+
+      <div className="mt-4 space-y-4">
+        <div className="space-y-2">
+          <Label className="text-sm font-medium text-maroon-900">Selection mode</Label>
+          <Tabs value={block.mode} onValueChange={(value) => handleModeChange(value as VerseSelectionMode)}>
+            <TabsList className="grid w-full grid-cols-2 bg-emerald-50/70">
+              <TabsTrigger value="range">Surah & ayah range</TabsTrigger>
+              <TabsTrigger value="custom">Custom verse keys</TabsTrigger>
+            </TabsList>
+            <TabsContent value="range" className="mt-4 space-y-4">
+              <div className="grid gap-4 md:grid-cols-3">
+                <div className="space-y-2">
+                  <Label className="text-xs uppercase text-emerald-700">Surah</Label>
+                  <Select value={block.surahNumber?.toString() ?? ""} onValueChange={handleSurahChange}>
+                    <SelectTrigger className="h-10 border-emerald-200/70">
+                      <SelectValue placeholder="Choose Surah" />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-60">
+                      {surahOptions.map((option) => (
+                        <SelectItem key={option.number} value={option.number.toString()}>
+                          {option.number}. {option.arabicName} ({option.englishName})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label className="text-xs uppercase text-emerald-700">From ayah</Label>
+                  <Select
+                    value={block.fromAyah?.toString() ?? ""}
+                    onValueChange={handleFromAyahChange}
+                    disabled={!selectedSurah}
+                  >
+                    <SelectTrigger className="h-10 border-emerald-200/70">
+                      <SelectValue placeholder="Start" />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-60">
+                      {ayahOptions.map((ayah) => (
+                        <SelectItem key={ayah} value={ayah.toString()}>
+                          Ayah {ayah}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label className="text-xs uppercase text-emerald-700">To ayah</Label>
+                  <Select
+                    value={block.toAyah?.toString() ?? ""}
+                    onValueChange={handleToAyahChange}
+                    disabled={!selectedSurah}
+                  >
+                    <SelectTrigger className="h-10 border-emerald-200/70">
+                      <SelectValue placeholder="End" />
+                    </SelectTrigger>
+                    <SelectContent className="max-h-60">
+                      {ayahOptions.map((ayah) => (
+                        <SelectItem key={ayah} value={ayah.toString()}>
+                          Ayah {ayah}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            </TabsContent>
+
+            <TabsContent value="custom" className="mt-4">
+              <div className="space-y-2">
+                <Label className="text-xs uppercase text-emerald-700">Verse keys</Label>
+                <Textarea
+                  placeholder="e.g., 112:1,112:2,2:255"
+                  value={block.customVerseKeys}
+                  onChange={(event) => onChange({ ...block, customVerseKeys: event.target.value })}
+                  rows={3}
+                  className="border-emerald-200/70"
+                />
+                <p className="text-xs text-emerald-700/80">
+                  Separate keys with commas. Use the format <strong>Surah:Ayah</strong>.
+                </p>
+              </div>
+            </TabsContent>
+          </Tabs>
+        </div>
+
+        {error && <p className="rounded-md bg-rose-50/80 px-3 py-2 text-sm text-rose-700">{error}</p>}
+      </div>
+    </div>
+  )
+}

--- a/hooks/useQuranVerses.ts
+++ b/hooks/useQuranVerses.ts
@@ -1,0 +1,44 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+
+import quranText from "@/data/quran-uthmani.json"
+import { normalizeVerseKey } from "@/lib/verse-validator"
+
+const verseCache = new Map<string, string>()
+const verseSource = quranText as Record<string, string>
+
+export interface VersePreview {
+  key: string
+  text: string
+}
+
+export function getCachedVerseText(key: string): string {
+  const normalized = normalizeVerseKey(key)
+  if (!normalized) {
+    return ""
+  }
+  if (verseCache.has(normalized)) {
+    return verseCache.get(normalized) ?? ""
+  }
+  const text = verseSource[normalized] ?? ""
+  verseCache.set(normalized, text)
+  return text
+}
+
+export function useQuranVerses(keys: string[]): { verses: VersePreview[]; isLoading: boolean } {
+  const [verses, setVerses] = useState<VersePreview[]>([])
+
+  const normalizedSignature = useMemo(
+    () => keys.map((key) => normalizeVerseKey(key)).join("|"),
+    [keys],
+  )
+
+  useEffect(() => {
+    const normalizedKeys = keys.map((key) => normalizeVerseKey(key)).filter((key) => key.length > 0)
+    const nextVerses = normalizedKeys.map((key) => ({ key, text: getCachedVerseText(key) }))
+    setVerses(nextVerses)
+  }, [normalizedSignature, keys])
+
+  return { verses, isLoading: false }
+}

--- a/lib/verse-validator.ts
+++ b/lib/verse-validator.ts
@@ -1,0 +1,134 @@
+import quranText from "@/data/quran-uthmani.json"
+import surahMeta from "@/data/quran.json"
+
+export type VerseKey = `${number}:${number}`
+
+interface SurahMetadataSource {
+  name: string
+  number_of_surah: number
+  number_of_ayah: number
+  name_translations?: Record<string, string>
+  place?: string
+  type?: string
+}
+
+export interface SurahOption {
+  number: number
+  arabicName: string
+  englishName: string
+  ayahCount: number
+}
+
+export interface VerseValidationIssue {
+  key: string
+  reason: string
+}
+
+export interface VerseValidationResult {
+  validKeys: string[]
+  issues: VerseValidationIssue[]
+}
+
+const verseMap = new Map<string, string>(Object.entries(quranText as Record<string, string>))
+
+const surahList = (surahMeta as SurahMetadataSource[]).map((surah) => ({
+  number: surah.number_of_surah,
+  arabicName: surah.name_translations?.ar ?? surah.name,
+  englishName: surah.name_translations?.en ?? surah.name,
+  ayahCount: surah.number_of_ayah,
+}))
+
+const surahMap = new Map<number, SurahOption>(surahList.map((entry) => [entry.number, entry]))
+
+export function getSurahOptions(): SurahOption[] {
+  return surahList.map((entry) => ({ ...entry }))
+}
+
+export function normalizeVerseKey(input: string): string {
+  const trimmed = input.trim()
+  if (!trimmed) {
+    return ""
+  }
+  const [surahPart, ayahPart] = trimmed.split(":")
+  const surahNumber = Number.parseInt(surahPart ?? "", 10)
+  const ayahNumber = Number.parseInt(ayahPart ?? "", 10)
+  if (!Number.isFinite(surahNumber) || !Number.isFinite(ayahNumber)) {
+    return trimmed
+  }
+  return `${surahNumber}:${ayahNumber}`
+}
+
+export function isValidVerseKey(verseKey: string): boolean {
+  const normalized = normalizeVerseKey(verseKey)
+  return verseMap.has(normalized)
+}
+
+export function expandVerseRange(surahNumber: number, fromAyah: number, toAyah?: number): string[] {
+  const surah = surahMap.get(surahNumber)
+  if (!surah) {
+    throw new Error(`Surah ${surahNumber} is not defined`)
+  }
+  if (!Number.isFinite(fromAyah) || fromAyah < 1) {
+    throw new Error("Starting ayah must be at least 1")
+  }
+  const normalizedTo = Number.isFinite(toAyah) ? toAyah ?? fromAyah : fromAyah
+  const start = Math.min(fromAyah, normalizedTo)
+  const end = Math.max(fromAyah, normalizedTo)
+  if (end > surah.ayahCount) {
+    throw new Error(`Surah ${surah.arabicName} contains only ${surah.ayahCount} ayat`)
+  }
+  const keys: string[] = []
+  for (let ayah = start; ayah <= end; ayah += 1) {
+    keys.push(`${surahNumber}:${ayah}`)
+  }
+  return keys
+}
+
+export function parseCommaSeparatedVerseKeys(input: string): string[] {
+  if (!input) {
+    return []
+  }
+  return input
+    .split(",")
+    .map((segment) => normalizeVerseKey(segment))
+    .filter((segment) => segment.length > 0)
+}
+
+export function validateVerseKeys(keys: string[]): VerseValidationResult {
+  const issues: VerseValidationIssue[] = []
+  const validKeys: string[] = []
+  keys.forEach((rawKey) => {
+    const normalized = normalizeVerseKey(rawKey)
+    if (!normalized) {
+      issues.push({ key: rawKey, reason: "Empty verse key" })
+      return
+    }
+    if (!verseMap.has(normalized)) {
+      issues.push({ key: normalized, reason: "Verse does not exist" })
+      return
+    }
+    validKeys.push(normalized)
+  })
+  return { validKeys, issues }
+}
+
+export function summarizeVerseKeys(keys: string[]): { verseCount: number; surahCount: number } {
+  const normalized = keys.map((key) => normalizeVerseKey(key))
+  const uniqueSurahs = new Set<number>()
+  normalized.forEach((key) => {
+    const [surahPart] = key.split(":")
+    const surahNumber = Number.parseInt(surahPart ?? "", 10)
+    if (Number.isFinite(surahNumber)) {
+      uniqueSurahs.add(surahNumber)
+    }
+  })
+  return {
+    verseCount: normalized.length,
+    surahCount: uniqueSurahs.size,
+  }
+}
+
+export function getVerseTextSafe(verseKey: string): string {
+  const normalized = normalizeVerseKey(verseKey)
+  return verseMap.get(normalized) ?? ""
+}


### PR DESCRIPTION
## Summary
- add a teacher-only memorization plan dashboard with creation, duplication, export, reminder, and progress views
- implement reusable plan creator, verse selector, and progress modal components backed by cached verse text helpers
- extend the in-memory data layer and expose API routes for teachers to manage plans, classes, and progress securely

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68e466ec50388327a6a084328b0cf0ea