### PR TITLE
Add teacher assignment persistence and integrate creation UI

### DIFF
--- a/lib/quran-data.ts
+++ b/lib/quran-data.ts
@@ -65,3 +65,7 @@ export function formatVerseReference(verseKey: string): string {
   const surah = getSurahInfo(surahNumber)
   return `${surah?.arabicName ?? `سورة ${surahNumber}`} • ${ayahNumber}`
 }
+
+export function listSurahs(): SurahInfo[] {
+  return Array.from(surahMap.values()).sort((a, b) => a.number - b.number)
+}


### PR DESCRIPTION
## Summary
- add assignment data models, helper utilities, and student submission tracking to the in-memory teacher database
- wire recitation logging, reviews, and dashboard summaries to update assignment submission state and recent-assignment metrics
- enhance the teacher assignment creation page with validation, toast feedback, and dynamic class/surah selection backed by the new data helpers

## Testing
- npm run lint *(fails: missing @eslint/eslintrc package in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e46a9abc6883278cfd7a467c393eb3