### PR TITLE
feat: add daily surah scheduler and enhanced memorization panel

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -20,6 +20,7 @@ import { PremiumGate } from "@/components/premium-gate"
 import { QuranFlipBook } from "@/components/quran-flipbook"
 import { LiveTajweedAnalyzer } from "@/components/live-tajweed-analyzer"
 import { useUser } from "@/hooks/use-user"
+import { getDailySurahRecommendations } from "@/lib/daily-surah"
 import {
   BookOpen,
   Play,
@@ -41,7 +42,6 @@ import {
   NotebookPen,
   UserCheck,
   Brain,
-  RefreshCw,
   Gamepad2,
   Flame,
   Zap,
@@ -85,7 +85,6 @@ export default function DashboardPage() {
     updateGoalProgress,
     toggleGoalCompletion,
     addGoal,
-    reviewMemorizationTask,
     completeRecitationAssignment,
     completeHabit,
   } = useUser()
@@ -108,12 +107,6 @@ export default function DashboardPage() {
   const leaderboardData = useMemo(() => dashboard?.leaderboard ?? [], [dashboard?.leaderboard])
   const recitationTasks = useMemo(() => dashboard?.recitationTasks ?? [], [dashboard?.recitationTasks])
   const recitationSessions = useMemo(() => dashboard?.recitationSessions ?? [], [dashboard?.recitationSessions])
-  const memorizationQueue = useMemo(() => dashboard?.memorizationQueue ?? [], [dashboard?.memorizationQueue])
-  const memorizationPlaylists = useMemo(
-    () => dashboard?.memorizationPlaylists ?? [],
-    [dashboard?.memorizationPlaylists],
-  )
-  const memorizationSummary = dashboard?.memorizationSummary
   const tajweedFocus = useMemo(() => dashboard?.tajweedFocus ?? [], [dashboard?.tajweedFocus])
   const dailyTargetCompleted = dailyTarget?.completedAyahs ?? 0
   const dailyTargetGoal = dailyTarget?.targetAyahs ?? 0
@@ -329,38 +322,34 @@ export default function DashboardPage() {
     [tajweedFocus],
   )
 
-  const memorizationDueToday = memorizationSummary?.dueToday ?? 0
-  const memorizationNewCount = memorizationSummary?.newCount ?? 0
-  const memorizationMastered = memorizationSummary?.totalMastered ?? 0
-  const memorizationRecommendedDuration = memorizationSummary?.recommendedDuration ?? 0
-  const memorizationHeatmap = memorizationSummary?.reviewHeatmap ?? []
+  const [dailySurahSuggestions, setDailySurahSuggestions] = useState(() => getDailySurahRecommendations(new Date()))
 
-  const sortedMemorizationQueue = useMemo(() => {
-    return [...memorizationQueue].sort(
-      (a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime(),
-    )
-  }, [memorizationQueue])
+  useEffect(() => {
+    setDailySurahSuggestions(getDailySurahRecommendations(new Date()))
+    const interval = setInterval(() => {
+      setDailySurahSuggestions(getDailySurahRecommendations(new Date()))
+    }, 60_000)
+    return () => clearInterval(interval)
+  }, [])
 
-  const memorizationDueTasks = useMemo(
-    () =>
-      sortedMemorizationQueue.filter((task) => {
-        const dueDate = new Date(task.dueDate)
-        const today = new Date()
-        dueDate.setHours(0, 0, 0, 0)
-        today.setHours(0, 0, 0, 0)
-        return dueDate.getTime() <= today.getTime()
-      }),
-    [sortedMemorizationQueue],
-  )
+  const dailySurahLog = dashboard?.dailySurahLog ?? []
 
-  const nextMemorizationTask = memorizationDueTasks[0] ?? sortedMemorizationQueue[0]
-
-  const handleMemorizationReview = useCallback(
-    (taskId: string) => {
-      reviewMemorizationTask({ taskId, quality: 4, accuracy: 95, durationSeconds: 180 })
-    },
-    [reviewMemorizationTask],
-  )
+  const { completedDailySurahSlugs, totalAvailableHasanat } = useMemo(() => {
+    const todayKey = new Date().toISOString().slice(0, 10)
+    const completed = new Set<string>()
+    for (const entry of dailySurahLog) {
+      if (entry.completedAt.slice(0, 10) === todayKey) {
+        completed.add(entry.slug)
+      }
+    }
+    let available = 0
+    for (const suggestion of dailySurahSuggestions) {
+      if (!completed.has(suggestion.slug)) {
+        available += suggestion.estimatedHasanat
+      }
+    }
+    return { completedDailySurahSlugs: completed, totalAvailableHasanat: available }
+  }, [dailySurahLog, dailySurahSuggestions])
 
   const recitationStatusStyles: Record<string, string> = {
     assigned: "bg-amber-100 text-amber-700 border border-amber-200",
@@ -397,15 +386,6 @@ export default function DashboardPage() {
     in_progress: "bg-maroon-100 text-maroon-700 border border-maroon-200",
     completed: "bg-emerald-100 text-emerald-700",
   }
-
-  const memorizationStatusLabels: Record<string, string> = {
-    new: "New",
-    due: "Due",
-    learning: "In Review",
-    mastered: "Mastered",
-  }
-
-  const taskStatusLabel = (status: string) => memorizationStatusLabels[status] ?? status
 
   const teacherMap = useMemo(() => new Map(teachers.map((teacher) => [teacher.id, teacher.name])), [teachers])
 
@@ -1043,162 +1023,93 @@ export default function DashboardPage() {
             <Card className="shadow-lg">
               <CardHeader>
                 <CardTitle className="text-xl flex items-center gap-2">
-                  <Brain className="w-5 h-5 text-maroon-600" />
-                  Memorization Studio
+                  <Sparkles className="w-5 h-5 text-maroon-600" />
+                  Daily Surah Rhythm
                 </CardTitle>
-                <CardDescription>Keep the spaced repetition queue healthy and on pace.</CardDescription>
+                <CardDescription>Real-time sunnah recitations to anchor your day with light and protection.</CardDescription>
               </CardHeader>
               <CardContent className="space-y-6">
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                  <div className="rounded-lg border border-rose-100 bg-rose-50/70 p-4">
-                    <p className="text-xs uppercase tracking-wide text-rose-600">Due today</p>
-                    <p className="text-3xl font-bold text-rose-700">{memorizationDueToday}</p>
-                    <p className="text-xs text-rose-600">{memorizationRecommendedDuration} min suggested</p>
-                  </div>
-                  <div className="rounded-lg border border-amber-100 bg-amber-50 p-4">
-                    <p className="text-xs uppercase tracking-wide text-amber-600">New cards</p>
-                    <p className="text-3xl font-bold text-amber-700">{memorizationNewCount}</p>
-                    <p className="text-xs text-amber-600">Introduce gradually for retention</p>
-                  </div>
-                  <div className="rounded-lg border border-emerald-100 bg-emerald-50 p-4">
-                    <p className="text-xs uppercase tracking-wide text-emerald-600">Mastered</p>
-                    <p className="text-3xl font-bold text-emerald-700">{memorizationMastered}</p>
-                    <p className="text-xs text-emerald-600">Confidence-backed mastery</p>
-                  </div>
-                  <div className="hidden md:block rounded-lg border border-maroon-100 bg-cream-50 p-4">
-                    <p className="text-xs uppercase tracking-wide text-maroon-600">Last review</p>
-                    <p className="text-lg font-semibold text-maroon-800">
-                      {memorizationSummary?.lastReviewedOn
-                        ? new Date(memorizationSummary.lastReviewedOn).toLocaleTimeString()
-                        : "Not yet"}
+                <div className="rounded-xl border border-maroon-100 bg-gradient-to-r from-maroon-50 via-amber-50 to-emerald-50 p-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                  <div>
+                    <p className="text-sm font-semibold text-maroon-900">
+                      Earn up to +{totalAvailableHasanat.toLocaleString()} hasanat this session
                     </p>
-                    <p className="text-xs text-maroon-600">Streak {memorizationSummary?.streak ?? 0} days</p>
+                    <p className="text-xs text-maroon-600">
+                      Choose a recommendation below to open the recitation flow and log your completion.
+                    </p>
+                  </div>
+                  <div className="text-xs text-gray-600">
+                    Updated {new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
                   </div>
                 </div>
 
-                {nextMemorizationTask ? (
-                  <div className="rounded-lg border border-maroon-100 bg-cream-50 p-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                    <div>
-                      <p className="text-xs uppercase tracking-wide text-maroon-600">Next focus</p>
-                      <p className="text-sm font-semibold text-maroon-900">
-                        {nextMemorizationTask.surah} • Ayah {nextMemorizationTask.ayahRange}
-                      </p>
-                      <p className="text-xs text-maroon-600">
-                        {memorizationSummary?.focusArea || nextMemorizationTask.notes || "Guided by your instructor"}
-                      </p>
-                    </div>
-                    <div className="flex flex-wrap items-center gap-3">
-                      <Badge variant="secondary" className="text-xs bg-white text-maroon-700">
-                        {taskStatusLabel(nextMemorizationTask.status)}
-                      </Badge>
-                      <Button
-                        size="sm"
-                        className="bg-gradient-to-r from-maroon-600 to-maroon-700 text-white border-0"
-                        onClick={() => handleMemorizationReview(nextMemorizationTask.id)}
+                <div className="grid gap-4 md:grid-cols-2">
+                  {dailySurahSuggestions.map((suggestion) => {
+                    const completed = completedDailySurahSlugs.has(suggestion.slug)
+                    const completionEntry = dailySurahLog.find((entry) => entry.slug === suggestion.slug)
+                    const sectionLabel = suggestion.sections.map((section) => section.englishName).join(" • ")
+                    return (
+                      <div
+                        key={suggestion.slug}
+                        className="rounded-lg border border-maroon-100 bg-white/90 p-4 shadow-sm flex flex-col gap-3"
                       >
-                        <CheckCircle2 className="w-4 h-4 mr-2" />
-                        Mark Reviewed
-                      </Button>
-                    </div>
-                  </div>
-                ) : (
-                  <div className="rounded-lg border border-dashed border-maroon-200 bg-maroon-50/60 p-4 text-sm text-maroon-700">
-                    No memorization tasks in the queue yet. Ask your teacher to assign a playlist to get started.
+                        <div className="flex items-start justify-between gap-3">
+                          <div>
+                            <p className="text-sm font-semibold text-maroon-900">{suggestion.title}</p>
+                            <p className="text-xs text-maroon-600">
+                              {suggestion.reason} • {suggestion.bestTimeLabel}
+                            </p>
+                          </div>
+                          <Badge
+                            variant="secondary"
+                            className={`text-xs ${completed ? "bg-emerald-100 text-emerald-700" : "bg-maroon-50 text-maroon-700"}`}
+                          >
+                            {completed ? "Completed today" : `+${suggestion.estimatedHasanat.toLocaleString()} hasanat`}
+                          </Badge>
+                        </div>
+                        <p className="text-sm text-gray-600">{suggestion.encouragement}</p>
+                        <div className="flex flex-wrap items-center gap-4 text-xs text-gray-500">
+                          <span>≈ {suggestion.estimatedMinutes} minutes</span>
+                          <span>{sectionLabel}</span>
+                        </div>
+                        <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-gray-500">
+                          {completionEntry ? (
+                            <span>
+                              Logged {new Date(completionEntry.completedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                            </span>
+                          ) : (
+                            <span>Tap recite to add hasanat to your ledger</span>
+                          )}
+                          <Button
+                            className={
+                              completed
+                                ? "border border-maroon-200 bg-white text-maroon-700"
+                                : "bg-gradient-to-r from-maroon-600 to-maroon-700 text-white border-0"
+                            }
+                            variant={completed ? "outline" : undefined}
+                            asChild
+                          >
+                            <Link href={`/student/daily-surahs/${suggestion.slug}`}>
+                              {completed ? "Revisit & reflect" : "Recite now"}
+                            </Link>
+                          </Button>
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+
+                {dailySurahSuggestions.length === 0 && (
+                  <div className="rounded-lg border border-dashed border-maroon-200 bg-white/70 p-4 text-sm text-gray-600">
+                    The daily scheduler is calibrating. Check back shortly for your recommended surahs.
                   </div>
                 )}
 
-                <div className="space-y-3">
-                  {sortedMemorizationQueue.slice(0, 4).map((task) => (
-                    <div
-                      key={task.id}
-                      className="rounded-lg border border-maroon-100 bg-white p-4 shadow-sm flex flex-col gap-3 md:flex-row md:items-center md:justify-between"
-                    >
-                      <div className="space-y-1">
-                        <p className="text-sm font-semibold text-maroon-900">
-                          {task.surah} • Ayah {task.ayahRange}
-                        </p>
-                        <div className="text-xs text-gray-600 flex flex-wrap items-center gap-3">
-                          <span>Due {new Date(task.dueDate).toLocaleDateString()}</span>
-                          <span>Interval: {task.interval} day{task.interval === 1 ? "" : "s"}</span>
-                          <span>Confidence {(task.memorizationConfidence * 100).toFixed(0)}%</span>
-                          <span>Teacher: {teacherMap.get(task.teacherId) ?? "Instructor"}</span>
-                        </div>
-                      </div>
-                      <div className="flex flex-wrap items-center gap-3">
-                        <Badge variant="secondary" className="text-xs bg-white text-maroon-700">
-                          {taskStatusLabel(task.status)}
-                        </Badge>
-                        <Button variant="outline" size="sm" onClick={() => handleMemorizationReview(task.id)}>
-                          <RefreshCw className="w-4 h-4 mr-2" /> Review
-                        </Button>
-                      </div>
-                    </div>
-                  ))}
-                  {sortedMemorizationQueue.length === 0 && (
-                    <div className="rounded-lg border border-dashed border-maroon-200 bg-white/70 p-4 text-center text-sm text-gray-600">
-                      Add ayahs to your memorization playlist to populate this view.
-                    </div>
-                  )}
-                </div>
-
-                <div className="grid gap-3 md:grid-cols-2">
-                  {memorizationPlaylists.slice(0, 2).map((playlist) => (
-                    <div key={playlist.id} className="rounded-lg border border-maroon-100 bg-white p-4">
-                      <div className="flex items-center justify-between mb-2">
-                        <p className="text-sm font-semibold text-maroon-900">{playlist.title}</p>
-                        <Badge variant="secondary" className="text-xs bg-maroon-50 text-maroon-700">
-                          {playlist.progress}%
-                        </Badge>
-                      </div>
-                      <p className="text-xs text-gray-600 mb-2">{playlist.description}</p>
-                      <div className="flex items-center justify-between text-xs text-gray-500">
-                        <span>{playlist.ayahCount} ayahs</span>
-                        <span>{playlist.dueCount} due</span>
-                      </div>
-                    </div>
-                  ))}
-                  {memorizationPlaylists.length === 0 && (
-                    <div className="rounded-lg border border-dashed border-maroon-200 bg-white/70 p-4 text-sm text-gray-600">
-                      Create a memorization playlist to track long-term goals.
-                    </div>
-                  )}
-                </div>
-
-                {memorizationHeatmap.length > 0 && (
-                  <div className="space-y-2">
-                    <p className="text-xs uppercase tracking-wide text-gray-500">Recent review momentum</p>
-                    <div className="flex gap-1 flex-wrap">
-                      {memorizationHeatmap.slice(0, 14).map((entry) => (
-                        <div
-                          key={entry.date}
-                          className={`h-6 w-6 rounded-md flex items-center justify-center text-[10px] font-medium ${
-                            entry.completed === 0
-                              ? "bg-gray-100 text-gray-400"
-                              : entry.completed >= 3
-                                ? "bg-maroon-600 text-white"
-                                : "bg-maroon-200 text-maroon-700"
-                          }`}
-                        >
-                          {entry.completed}
-                        </div>
-                      ))}
-                    </div>
+                {completedDailySurahSlugs.size === dailySurahSuggestions.length && dailySurahSuggestions.length > 0 && (
+                  <div className="rounded-lg border border-emerald-200 bg-emerald-50/80 p-4 text-sm text-emerald-800">
+                    Masha’Allah! You’ve completed today’s highlighted surahs. Revisit any time for extra reflection.
                   </div>
                 )}
-
-                <div className="flex flex-wrap justify-end gap-3">
-                  <Button variant="outline" asChild>
-                    <Link href="/student/memorization">Open Memorization Panel</Link>
-                  </Button>
-                  {nextMemorizationTask && (
-                    <Button
-                      className="bg-gradient-to-r from-maroon-600 to-maroon-700 text-white border-0"
-                      asChild
-                    >
-                      <Link href={`/student/memorization?focus=${nextMemorizationTask.id}`}>Start Focus Session</Link>
-                    </Button>
-                  )}
-                </div>
               </CardContent>
             </Card>
 

--- a/app/student/daily-surahs/[slug]/page.tsx
+++ b/app/student/daily-surahs/[slug]/page.tsx
@@ -1,0 +1,54 @@
+import { notFound, redirect } from "next/navigation"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { getActiveSession } from "@/lib/data/auth"
+import { getDailySurahDetail } from "@/lib/daily-surah"
+import { DailySurahRecitationExperience } from "./recitation-experience"
+
+interface DailySurahPageProps {
+  params: { slug: string }
+}
+
+export default function DailySurahPage({ params }: DailySurahPageProps) {
+  const session = getActiveSession()
+  if (!session) {
+    redirect("/auth/sign-in")
+  }
+  if (session.role !== "student") {
+    redirect("/dashboard")
+  }
+
+  const detail = getDailySurahDetail(params.slug)
+  if (!detail) {
+    notFound()
+  }
+
+  const firstSection = detail.sections[0]
+  const subtitle = firstSection
+    ? `${firstSection.arabicName} • ${firstSection.ayahCount} ayahs`
+    : "Guided recitation"
+
+  return (
+    <div className="min-h-screen bg-amber-50/70 py-12">
+      <div className="mx-auto flex max-w-5xl flex-col gap-8 px-6">
+        <header className="space-y-4 text-maroon-900">
+          <Badge className="w-fit bg-maroon-700 text-white">Daily Surahs</Badge>
+          <div className="space-y-2">
+            <h1 className="text-3xl font-semibold">{detail.title}</h1>
+            <p className="text-sm text-maroon-700">{detail.encouragement}</p>
+          </div>
+        </header>
+
+        <Card className="border-maroon-100 bg-white/90 shadow-lg">
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-2xl text-maroon-900">Recitation Flow</CardTitle>
+            <CardDescription className="text-maroon-600">{subtitle}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <DailySurahRecitationExperience detail={detail} />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/student/daily-surahs/[slug]/recitation-experience.tsx
+++ b/app/student/daily-surahs/[slug]/recitation-experience.tsx
@@ -1,0 +1,194 @@
+"use client"
+
+import Link from "next/link"
+import { useCallback, useMemo, useState } from "react"
+import { BookOpen, Clock, Sparkles, Trophy } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { useToast } from "@/hooks/use-toast"
+import { useUser } from "@/hooks/use-user"
+import type { DailySurahRecommendation } from "@/lib/daily-surah"
+
+interface DailySurahRecitationExperienceProps {
+  detail: DailySurahRecommendation
+}
+
+export function DailySurahRecitationExperience({ detail }: DailySurahRecitationExperienceProps) {
+  const { dashboard, completeDailySurahRecitation } = useUser()
+  const { toast } = useToast()
+  const [isCelebrating, setIsCelebrating] = useState(false)
+  const [celebrationMessage, setCelebrationMessage] = useState<string | null>(null)
+
+  const todayKey = useMemo(() => new Date().toISOString().slice(0, 10), [])
+  const todaysCompletion = useMemo(() => {
+    return dashboard?.dailySurahLog.find(
+      (entry) => entry.slug === detail.slug && entry.completedAt.slice(0, 10) === todayKey,
+    )
+  }, [dashboard?.dailySurahLog, detail.slug, todayKey])
+
+  const totalAyahs = useMemo(
+    () => detail.sections.reduce((sum, section) => sum + section.ayahCount, 0),
+    [detail.sections],
+  )
+
+  const launchConfetti = useCallback(async () => {
+    const confetti = (await import("canvas-confetti")).default
+    confetti({
+      particleCount: 240,
+      spread: 75,
+      origin: { y: 0.6 },
+      scalar: 1.2,
+      colors: ["#0f766e", "#10b981", "#f59e0b", "#fde68a", "#dc2626"],
+    })
+  }, [])
+
+  const handleCompletion = useCallback(() => {
+    const result = completeDailySurahRecitation({
+      slug: detail.slug,
+      surahNumber: detail.sections[0]?.surahNumber ?? 0,
+      title: detail.title,
+      encouragement: detail.encouragement,
+      hasanatAwarded: detail.estimatedHasanat,
+      ayahsRead: totalAyahs,
+      studyMinutes: detail.estimatedMinutes,
+    })
+
+    if (result.alreadyCompleted) {
+      toast({
+        title: "Already counted",
+        description: "Today's recitation is already logged. Feel free to reflect again!",
+      })
+      return
+    }
+
+    toast({
+      title: "Masha’Allah!",
+      description: `+${result.hasanatAwarded.toLocaleString()} hasanat added to your ledger.`,
+    })
+    setCelebrationMessage("Masha’Allah! Your nightly ledger just blossomed with light.")
+    setIsCelebrating(true)
+    void launchConfetti()
+    window.setTimeout(() => {
+      setIsCelebrating(false)
+      setCelebrationMessage(null)
+    }, 5000)
+  }, [completeDailySurahRecitation, detail, launchConfetti, toast, totalAyahs])
+
+  return (
+    <div className="space-y-8">
+      <section className="grid gap-4 sm:grid-cols-2">
+        <Card className="border-maroon-100 bg-maroon-50/60">
+          <CardHeader className="flex flex-row items-center gap-3 pb-2">
+            <div className="rounded-lg bg-white/80 p-2 text-maroon-700">
+              <Sparkles className="h-5 w-5" />
+            </div>
+            <CardTitle className="text-base text-maroon-900">Hasanat Potential</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-maroon-700">
+            <p className="text-2xl font-semibold text-maroon-900">
+              +{detail.estimatedHasanat.toLocaleString()} hasanat
+            </p>
+            <p className="mt-1 text-xs">
+              {detail.estimatedLetters.toLocaleString()} letters • {detail.sections.length} surah{detail.sections.length === 1 ? "" : "s"}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="border-emerald-100 bg-emerald-50/70">
+          <CardHeader className="flex flex-row items-center gap-3 pb-2">
+            <div className="rounded-lg bg-white/80 p-2 text-emerald-700">
+              <Clock className="h-5 w-5" />
+            </div>
+            <CardTitle className="text-base text-emerald-900">Estimated Focus Time</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-emerald-700">
+            <p className="text-2xl font-semibold text-emerald-900">≈ {detail.estimatedMinutes} minutes</p>
+            <p className="mt-1 text-xs">{totalAyahs} ayahs across the highlighted surahs.</p>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex flex-col gap-3 rounded-2xl border border-maroon-100 bg-cream-50 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1 text-sm text-maroon-700">
+            <p className="font-semibold text-maroon-900">
+              {todaysCompletion
+                ? "Alhamdulillah! Today's recitation is logged."
+                : "Ready to recite? Complete to unlock today's hasanat."}
+            </p>
+            <p className="text-xs text-maroon-600">
+              {todaysCompletion
+                ? `Logged at ${new Date(todaysCompletion.completedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`
+                : "Recite with presence, then tap complete to shower your ledger."}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              className="bg-gradient-to-r from-maroon-600 to-maroon-700 text-white border-0"
+              onClick={handleCompletion}
+            >
+              {todaysCompletion ? "Celebrate again" : "Mark recitation complete"}
+            </Button>
+            <Button variant="outline" asChild>
+              <Link href={`/reader?surah=${detail.sections[0]?.surahNumber ?? 1}`}>
+                <BookOpen className="mr-2 h-4 w-4" />
+                Open Reader
+              </Link>
+            </Button>
+          </div>
+        </div>
+
+        {isCelebrating && celebrationMessage && (
+          <div className="rounded-2xl border border-emerald-200 bg-emerald-50/80 p-4 text-center text-emerald-800 shadow-md">
+            {celebrationMessage}
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-4">
+        {detail.sections.map((section) => (
+          <Card key={section.surahNumber} className="border-maroon-100 bg-white/95">
+            <CardHeader>
+              <CardTitle className="flex flex-wrap items-center gap-3 text-maroon-900">
+                <Badge className="bg-maroon-600 text-white">Surah {section.englishName}</Badge>
+                <span className="text-sm text-maroon-600">{section.arabicName}</span>
+                <span className="text-xs text-gray-500">{section.ayahCount} ayahs</span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="rounded-xl border border-maroon-100 bg-cream-50 p-3 text-sm text-maroon-700">
+                Focus intention: renew sincerity before starting and end with du'a for steadfastness.
+              </div>
+              <ScrollArea className="h-64 rounded-xl border border-gray-100 bg-white p-4">
+                <ol className="space-y-3 text-right font-[\"Scheherazade\"] text-lg leading-relaxed text-maroon-900">
+                  {section.verses.map((verse) => (
+                    <li key={verse.key} className="space-y-1">
+                      <p>{verse.text}</p>
+                      <p className="text-left text-xs text-gray-500">{verse.key}</p>
+                    </li>
+                  ))}
+                </ol>
+              </ScrollArea>
+            </CardContent>
+          </Card>
+        ))}
+      </section>
+
+      <section className="rounded-2xl border border-amber-200 bg-amber-50/80 p-4 text-sm text-amber-800">
+        <div className="flex flex-wrap items-center gap-3">
+          <Trophy className="h-5 w-5" />
+          <div>
+            <p className="font-medium text-amber-900">Virtue spotlight</p>
+            <p>
+              These surahs brighten your week: Al-Kahf for Friday light, Al-Mulk for nightly protection, and the Quls for
+              heartfelt shielding.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/student/memorization/page.tsx
+++ b/app/student/memorization/page.tsx
@@ -9,6 +9,7 @@ import { Progress } from "@/components/ui/progress"
 import { getActiveSession } from "@/lib/data/auth"
 import { listStudentMemorizationPlans } from "@/lib/data/teacher-database"
 import { formatVerseReference } from "@/lib/quran-data"
+import { MemorizationStudioPanel } from "@/components/memorization/memorization-studio-panel"
 
 const REPETITION_TARGET = 20
 
@@ -59,6 +60,8 @@ export default function StudentMemorizationPage() {
             <AlertDescription>{nudgeMessage}</AlertDescription>
           </Alert>
         )}
+
+        <MemorizationStudioPanel />
 
         {assignedPlans.length === 0 ? (
           <Card className="border-dashed border-emerald-200 bg-white/80">

--- a/components/memorization/memorization-studio-panel.tsx
+++ b/components/memorization/memorization-studio-panel.tsx
@@ -1,0 +1,233 @@
+"use client"
+
+import Link from "next/link"
+import { useCallback, useMemo } from "react"
+import { Brain, CheckCircle2, RefreshCw } from "lucide-react"
+
+import { useUser } from "@/hooks/use-user"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+
+const memorizationStatusLabels: Record<string, string> = {
+  new: "New",
+  due: "Due",
+  learning: "In Review",
+  mastered: "Mastered",
+}
+
+const taskStatusLabel = (status: string) => memorizationStatusLabels[status] ?? status
+
+export function MemorizationStudioPanel() {
+  const { dashboard, teachers, reviewMemorizationTask } = useUser()
+
+  const memorizationSummary = dashboard?.memorizationSummary
+  const memorizationQueue = useMemo(() => dashboard?.memorizationQueue ?? [], [dashboard?.memorizationQueue])
+  const memorizationPlaylists = useMemo(
+    () => dashboard?.memorizationPlaylists ?? [],
+    [dashboard?.memorizationPlaylists],
+  )
+  const teacherMap = useMemo(() => new Map(teachers.map((teacher) => [teacher.id, teacher.name])), [teachers])
+
+  const memorizationDueToday = memorizationSummary?.dueToday ?? 0
+  const memorizationNewCount = memorizationSummary?.newCount ?? 0
+  const memorizationMastered = memorizationSummary?.totalMastered ?? 0
+  const memorizationRecommendedDuration = memorizationSummary?.recommendedDuration ?? 0
+  const memorizationHeatmap = memorizationSummary?.reviewHeatmap ?? []
+
+  const sortedMemorizationQueue = useMemo(() => {
+    return [...memorizationQueue].sort(
+      (a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime(),
+    )
+  }, [memorizationQueue])
+
+  const memorizationDueTasks = useMemo(
+    () =>
+      sortedMemorizationQueue.filter((task) => {
+        const dueDate = new Date(task.dueDate)
+        const today = new Date()
+        dueDate.setHours(0, 0, 0, 0)
+        today.setHours(0, 0, 0, 0)
+        return dueDate.getTime() <= today.getTime()
+      }),
+    [sortedMemorizationQueue],
+  )
+
+  const nextMemorizationTask = memorizationDueTasks[0] ?? sortedMemorizationQueue[0]
+
+  const handleMemorizationReview = useCallback(
+    (taskId: string) => {
+      reviewMemorizationTask({ taskId, quality: 4, accuracy: 95, durationSeconds: 180 })
+    },
+    [reviewMemorizationTask],
+  )
+
+  if (!dashboard) {
+    return null
+  }
+
+  return (
+    <Card className="shadow-lg border-emerald-100/60 bg-white/95">
+      <CardHeader>
+        <CardTitle className="text-xl flex items-center gap-2 text-maroon-900">
+          <Brain className="w-5 h-5 text-maroon-600" />
+          Memorization Studio
+        </CardTitle>
+        <CardDescription className="text-maroon-600">
+          Keep the spaced repetition queue healthy and celebrate every review.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className="rounded-lg border border-rose-100 bg-rose-50/70 p-4">
+            <p className="text-xs uppercase tracking-wide text-rose-600">Due today</p>
+            <p className="text-3xl font-bold text-rose-700">{memorizationDueToday}</p>
+            <p className="text-xs text-rose-600">{memorizationRecommendedDuration} min suggested</p>
+          </div>
+          <div className="rounded-lg border border-amber-100 bg-amber-50 p-4">
+            <p className="text-xs uppercase tracking-wide text-amber-600">New cards</p>
+            <p className="text-3xl font-bold text-amber-700">{memorizationNewCount}</p>
+            <p className="text-xs text-amber-600">Introduce gradually for retention</p>
+          </div>
+          <div className="rounded-lg border border-emerald-100 bg-emerald-50 p-4">
+            <p className="text-xs uppercase tracking-wide text-emerald-600">Mastered</p>
+            <p className="text-3xl font-bold text-emerald-700">{memorizationMastered}</p>
+            <p className="text-xs text-emerald-600">Confidence-backed mastery</p>
+          </div>
+          <div className="hidden md:block rounded-lg border border-maroon-100 bg-cream-50 p-4">
+            <p className="text-xs uppercase tracking-wide text-maroon-600">Last review</p>
+            <p className="text-lg font-semibold text-maroon-800">
+              {memorizationSummary?.lastReviewedOn
+                ? new Date(memorizationSummary.lastReviewedOn).toLocaleTimeString()
+                : "Not yet"}
+            </p>
+            <p className="text-xs text-maroon-600">Streak {memorizationSummary?.streak ?? 0} days</p>
+          </div>
+        </div>
+
+        {nextMemorizationTask ? (
+          <div className="rounded-lg border border-maroon-100 bg-cream-50 p-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-maroon-600">Next focus</p>
+              <p className="text-sm font-semibold text-maroon-900">
+                {nextMemorizationTask.surah} • Ayah {nextMemorizationTask.ayahRange}
+              </p>
+              <p className="text-xs text-maroon-600">
+                {memorizationSummary?.focusArea || nextMemorizationTask.notes || "Guided by your instructor"}
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <Badge variant="secondary" className="text-xs bg-white text-maroon-700">
+                {taskStatusLabel(nextMemorizationTask.status)}
+              </Badge>
+              <Button
+                size="sm"
+                className="bg-gradient-to-r from-maroon-600 to-maroon-700 text-white border-0"
+                onClick={() => handleMemorizationReview(nextMemorizationTask.id)}
+              >
+                <CheckCircle2 className="w-4 h-4 mr-2" />
+                Mark Reviewed
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed border-maroon-200 bg-maroon-50/60 p-4 text-sm text-maroon-700">
+            No memorization tasks in the queue yet. Ask your teacher to assign a playlist to get started.
+          </div>
+        )}
+
+        <div className="space-y-3">
+          {sortedMemorizationQueue.slice(0, 4).map((task) => (
+            <div
+              key={task.id}
+              className="rounded-lg border border-maroon-100 bg-white p-4 shadow-sm flex flex-col gap-3 md:flex-row md:items-center md:justify-between"
+            >
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-maroon-900">
+                  {task.surah} • Ayah {task.ayahRange}
+                </p>
+                <div className="text-xs text-gray-600 flex flex-wrap items-center gap-3">
+                  <span>Due {new Date(task.dueDate).toLocaleDateString()}</span>
+                  <span>Interval: {task.interval} day{task.interval === 1 ? "" : "s"}</span>
+                  <span>Confidence {(task.memorizationConfidence * 100).toFixed(0)}%</span>
+                  <span>Teacher: {teacherMap.get(task.teacherId) ?? "Instructor"}</span>
+                </div>
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                <Badge variant="secondary" className="text-xs bg-white text-maroon-700">
+                  {taskStatusLabel(task.status)}
+                </Badge>
+                <Button variant="outline" size="sm" onClick={() => handleMemorizationReview(task.id)}>
+                  <RefreshCw className="w-4 h-4 mr-2" /> Review
+                </Button>
+              </div>
+            </div>
+          ))}
+          {sortedMemorizationQueue.length === 0 && (
+            <div className="rounded-lg border border-dashed border-maroon-200 bg-white/70 p-4 text-center text-sm text-gray-600">
+              Add ayahs to your memorization playlist to populate this view.
+            </div>
+          )}
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2">
+          {memorizationPlaylists.slice(0, 2).map((playlist) => (
+            <div key={playlist.id} className="rounded-lg border border-maroon-100 bg-white p-4">
+              <div className="flex items-center justify-between mb-2">
+                <p className="text-sm font-semibold text-maroon-900">{playlist.title}</p>
+                <Badge variant="secondary" className="text-xs bg-maroon-50 text-maroon-700">
+                  {playlist.progress}%
+                </Badge>
+              </div>
+              <p className="text-xs text-gray-600 mb-2">{playlist.description}</p>
+              <div className="flex items-center justify-between text-xs text-gray-500">
+                <span>{playlist.ayahCount} ayahs</span>
+                <span>{playlist.dueCount} due</span>
+              </div>
+            </div>
+          ))}
+          {memorizationPlaylists.length === 0 && (
+            <div className="rounded-lg border border-dashed border-maroon-200 bg-white/70 p-4 text-sm text-gray-600">
+              Create a memorization playlist to track long-term goals.
+            </div>
+          )}
+        </div>
+
+        {memorizationHeatmap.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-xs uppercase tracking-wide text-gray-500">Recent review momentum</p>
+            <div className="flex gap-1 flex-wrap">
+              {memorizationHeatmap.slice(0, 14).map((entry) => (
+                <div
+                  key={entry.date}
+                  className={`h-6 w-6 rounded-md flex items-center justify-center text-[10px] font-medium ${
+                    entry.completed === 0
+                      ? "bg-gray-100 text-gray-400"
+                      : entry.completed >= 3
+                        ? "bg-maroon-600 text-white"
+                        : "bg-maroon-200 text-maroon-700"
+                  }`}
+                >
+                  {entry.completed}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="flex flex-wrap justify-end gap-3">
+          <Button variant="outline" asChild>
+            <Link href="/student/memorization">Open Memorization Panel</Link>
+          </Button>
+          {nextMemorizationTask && (
+            <Button className="bg-gradient-to-r from-maroon-600 to-maroon-700 text-white border-0" asChild>
+              <Link href={`/student/memorization?focus=${nextMemorizationTask.id}`}>
+                Start Focus Session
+              </Link>
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/user-provider.tsx
+++ b/components/user-provider.tsx
@@ -27,6 +27,9 @@ import {
   type SubscriptionPlan,
   type RecitationSubmissionInput,
   type MemorizationReviewInput,
+  recordDailySurahCompletion as persistDailySurahCompletion,
+  type DailySurahCompletionInput,
+  type DailySurahCompletionResult,
 } from "@/lib/data/teacher-database"
 import { getActiveSession } from "@/lib/data/auth"
 
@@ -59,6 +62,7 @@ interface UserContextValue {
   submitRecitationResult: (submission: RecitationSubmissionInput) => void
   completeRecitationAssignment: (taskId: string) => void
   reviewMemorizationTask: (review: MemorizationReviewInput) => void
+  completeDailySurahRecitation: (completion: DailySurahCompletionInput) => DailySurahCompletionResult
 }
 
 const perksByPlan: Record<SubscriptionPlan, string[]> = {
@@ -145,6 +149,7 @@ function createFallbackDashboardRecord(studentId: string): StudentDashboardRecor
       boosts: [],
       leaderboard: { rank: 0, nextReward: 0, classRank: 0 },
     },
+    dailySurahLog: [],
   }
 }
 
@@ -338,6 +343,17 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     [applyLearnerState, studentId],
   )
 
+  const completeDailySurahRecitation = useCallback(
+    (completion: DailySurahCompletionInput) => {
+      const response = persistDailySurahCompletion(studentId, completion)
+      if (response.state) {
+        applyLearnerState(response.state)
+      }
+      return response.result
+    },
+    [applyLearnerState, studentId],
+  )
+
   const completeRecitationAssignment = useCallback(
     (taskId: string) => {
       const task = dashboard?.recitationTasks.find((entry) => entry.id === taskId)
@@ -434,6 +450,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
       submitRecitationResult,
       completeRecitationAssignment,
       reviewMemorizationTask,
+      completeDailySurahRecitation,
       upgradeToPremium,
       downgradeToFree,
     }),
@@ -459,6 +476,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
       submitRecitationResult,
       completeRecitationAssignment,
       reviewMemorizationTask,
+      completeDailySurahRecitation,
       upgradeToPremium,
       downgradeToFree,
     ],

--- a/lib/daily-surah.ts
+++ b/lib/daily-surah.ts
@@ -1,0 +1,169 @@
+import { getSurahInfo, getVerseText } from "@/lib/quran-data"
+
+export interface DailySurahSection {
+  surahNumber: number
+  arabicName: string
+  englishName: string
+  ayahCount: number
+  verses: { key: string; text: string }[]
+}
+
+export interface DailySurahRecommendation {
+  slug: string
+  title: string
+  encouragement: string
+  reason: string
+  bestTimeLabel: string
+  estimatedHasanat: number
+  estimatedLetters: number
+  estimatedMinutes: number
+  sections: DailySurahSection[]
+}
+
+const LETTER_HASANAT_MULTIPLIER = 10
+
+const BASE_RECOMMENDATIONS = {
+  kahf: {
+    slug: "surah-al-kahf",
+    title: "Friday Light • Surah Al-Kahf",
+    encouragement:
+      "It's Friday—reciting Surah Al-Kahf brings a light between this week and the next. Seek the protection of its stories today.",
+    reason: "Beloved Sunnah for Fridays",
+    bestTimeLabel: "Friday daylight",
+    surahs: [18],
+  },
+  mulk: {
+    slug: "surah-al-mulk",
+    title: "Night Protection • Surah Al-Mulk",
+    encouragement:
+      "Before resting, recite Surah Al-Mulk. Its intercession protects the believer until the morning, in shaa Allah.",
+    reason: "Prophetic nighttime routine",
+    bestTimeLabel: "After Isha",
+    surahs: [67],
+  },
+  quls: {
+    slug: "evening-protection-quls",
+    title: "Evening Shield • Three Quls",
+    encouragement:
+      "Wrap up the day with Surah Al-Ikhlas, Al-Falaq, and An-Nas for protection and serenity.",
+    reason: "Nightly protection trio",
+    bestTimeLabel: "After Maghrib",
+    surahs: [112, 113, 114],
+  },
+  yasin: {
+    slug: "morning-surah-yasin",
+    title: "Morning Barakah • Surah Yasin",
+    encouragement:
+      "Begin your day with Surah Yasin to soften the heart and invite barakah into every step.",
+    reason: "Daybreak devotion",
+    bestTimeLabel: "Early morning",
+    surahs: [36],
+  },
+  waqiah: {
+    slug: "sustenance-surah-waqiah",
+    title: "Sustenance Reminder • Surah Al-Waqiah",
+    encouragement:
+      "An afternoon recitation of Surah Al-Waqiah is a timeless reminder that provision flows from Allah alone.",
+    reason: "Afternoon reflection",
+    bestTimeLabel: "Afternoon",
+    surahs: [56],
+  },
+} as const
+
+type RecommendationKey = keyof typeof BASE_RECOMMENDATIONS
+
+function getVersesForSurah(surahNumber: number): DailySurahSection {
+  const surahInfo = getSurahInfo(surahNumber)
+  const ayahCount = surahInfo?.ayahCount ?? 0
+  const verses: { key: string; text: string }[] = []
+
+  for (let ayah = 1; ayah <= ayahCount; ayah += 1) {
+    const key = `${surahNumber}:${ayah}`
+    verses.push({ key, text: getVerseText(key) })
+  }
+
+  return {
+    surahNumber,
+    arabicName: surahInfo?.arabicName ?? `سورة ${surahNumber}`,
+    englishName: surahInfo?.englishName ?? `Surah ${surahNumber}`,
+    ayahCount,
+    verses,
+  }
+}
+
+function countArabicLetters(text: string): number {
+  const matches = text.match(/[\u0621-\u064A]/g)
+  return matches ? matches.length : 0
+}
+
+function buildRecommendation(key: RecommendationKey): DailySurahRecommendation {
+  const config = BASE_RECOMMENDATIONS[key]
+  const sections = config.surahs.map(getVersesForSurah)
+  const totalLetters = sections.reduce((sum, section) => {
+    const sectionLetters = section.verses.reduce((count, verse) => count + countArabicLetters(verse.text), 0)
+    return sum + sectionLetters
+  }, 0)
+  const totalAyahs = sections.reduce((sum, section) => sum + section.ayahCount, 0)
+  const estimatedMinutes = Math.max(5, Math.round(totalAyahs * 0.75))
+
+  return {
+    slug: config.slug,
+    title: config.title,
+    encouragement: config.encouragement,
+    reason: config.reason,
+    bestTimeLabel: config.bestTimeLabel,
+    estimatedHasanat: totalLetters * LETTER_HASANAT_MULTIPLIER,
+    estimatedLetters: totalLetters,
+    estimatedMinutes,
+    sections,
+  }
+}
+
+export function getDailySurahRecommendations(now: Date = new Date()): DailySurahRecommendation[] {
+  const day = now.getDay()
+  const hour = now.getHours()
+  const recommendations: DailySurahRecommendation[] = []
+
+  if (day === 5) {
+    recommendations.push(buildRecommendation("kahf"))
+  }
+
+  if (hour >= 18) {
+    recommendations.push(buildRecommendation("mulk"))
+    recommendations.push(buildRecommendation("quls"))
+  } else if (hour < 10) {
+    recommendations.push(buildRecommendation("yasin"))
+  } else {
+    recommendations.push(buildRecommendation("waqiah"))
+  }
+
+  if (recommendations.length === 0) {
+    recommendations.push(buildRecommendation("yasin"))
+  }
+
+  return recommendations
+}
+
+export function getDailySurahDetail(slug: string, now: Date = new Date()): DailySurahRecommendation | null {
+  const recommendationKeys = Object.keys(BASE_RECOMMENDATIONS) as RecommendationKey[]
+  const key = recommendationKeys.find((candidate) => BASE_RECOMMENDATIONS[candidate].slug === slug)
+  if (!key) {
+    return null
+  }
+
+  const recommendation = buildRecommendation(key)
+
+  if (key === "kahf") {
+    return recommendation
+  }
+
+  if (key === "mulk" || key === "quls") {
+    return recommendation
+  }
+
+  if (key === "yasin" && now.getHours() >= 10) {
+    return buildRecommendation("waqiah")
+  }
+
+  return recommendation
+}


### PR DESCRIPTION
## Summary
- add a reusable daily surah recommendation helper with time-aware scheduling and hasanat estimates
- persist daily surah completions, including new dashboard log entries and hasanat rewards
- move the memorization studio UI into the dedicated panel and replace the dashboard card with a dynamic daily surah widget
- introduce a daily surah recitation flow that celebrates completion and routes students to the reader

## Testing
- npm run lint *(fails: missing optional dependency @eslint/eslintrc in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e46c998ac08327b5b95dff9edd0694