### PR TITLE
Implement teacher assignment creation flow

### DIFF
--- a/app/api/teacher/assignments/route.ts
+++ b/app/api/teacher/assignments/route.ts
@@ -1,0 +1,166 @@
+import { NextResponse } from "next/server"
+
+import { getActiveSession } from "@/lib/data/auth"
+import {
+  createTeacherAssignment,
+  deleteTeacherAssignment,
+  getTeacherAssignment,
+  listTeacherAssignments,
+  type AssignmentHotspotInput,
+  type AssignmentStatus,
+  type AssignmentWithStats,
+} from "@/lib/data/teacher-database"
+
+function combineDateAndTime(date: string | undefined, time: string | undefined): string | null {
+  const trimmedDate = date?.trim()
+  if (!trimmedDate) {
+    return null
+  }
+  const trimmedTime = time?.trim()
+  const normalizedTime = trimmedTime
+    ? trimmedTime.length === 5
+      ? `${trimmedTime}:00`
+      : trimmedTime
+    : "23:59:00"
+  const candidate = new Date(`${trimmedDate}T${normalizedTime}`)
+  if (Number.isNaN(candidate.getTime())) {
+    return null
+  }
+  return candidate.toISOString()
+}
+
+function sanitizeHotspots(raw: unknown): AssignmentHotspotInput[] {
+  if (!Array.isArray(raw)) {
+    return []
+  }
+  return raw
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return null
+      }
+      const candidate = entry as Partial<AssignmentHotspotInput>
+      if (
+        typeof candidate.title !== "string" ||
+        typeof candidate.description !== "string" ||
+        typeof candidate.x !== "number" ||
+        typeof candidate.y !== "number" ||
+        typeof candidate.width !== "number" ||
+        typeof candidate.height !== "number"
+      ) {
+        return null
+      }
+      return {
+        title: candidate.title,
+        description: candidate.description,
+        x: candidate.x,
+        y: candidate.y,
+        width: candidate.width,
+        height: candidate.height,
+        audioUrl: typeof candidate.audioUrl === "string" ? candidate.audioUrl : undefined,
+      }
+    })
+    .filter((hotspot): hotspot is AssignmentHotspotInput => hotspot !== null)
+}
+
+function serializeAssignment(summary: AssignmentWithStats) {
+  return {
+    assignment: {
+      ...summary.assignment,
+      classIds: [...summary.assignment.classIds],
+      studentIds: [...summary.assignment.studentIds],
+      hotspots: summary.assignment.hotspots.map((hotspot) => ({ ...hotspot })),
+    },
+    stats: { ...summary.stats },
+    submissions: summary.submissions.map((submission) => ({ ...submission })),
+  }
+}
+
+export function GET() {
+  const session = getActiveSession()
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  if (session.role !== "teacher") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const assignments = listTeacherAssignments(session.userId).map((summary) => serializeAssignment(summary))
+  return NextResponse.json({ assignments })
+}
+
+export async function POST(request: Request) {
+  const session = getActiveSession()
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  if (session.role !== "teacher") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  let payload: Record<string, unknown>
+  try {
+    payload = (await request.json()) as Record<string, unknown>
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 })
+  }
+
+  const title = typeof payload.title === "string" ? payload.title : ""
+  const assignmentType = typeof payload.assignmentType === "string" ? payload.assignmentType : "recitation"
+  const surahName = typeof payload.surahName === "string" ? payload.surahName : ""
+  const surahNumber = Number(payload.surahNumber)
+  const ayahRange = typeof payload.ayahRange === "string" ? payload.ayahRange : ""
+  const dueDate = typeof payload.dueDate === "string" ? payload.dueDate : undefined
+  const dueTime = typeof payload.dueTime === "string" ? payload.dueTime : undefined
+  const dueAt = combineDateAndTime(dueDate, dueTime)
+  const classIds = Array.isArray(payload.classIds)
+    ? payload.classIds.filter((value): value is string => typeof value === "string")
+    : []
+  const studentIds = Array.isArray(payload.studentIds)
+    ? payload.studentIds.filter((value): value is string => typeof value === "string")
+    : []
+  const status: AssignmentStatus = payload.publish ? "published" : "draft"
+  const description = typeof payload.description === "string" ? payload.description : undefined
+  const instructions = typeof payload.instructions === "string" ? payload.instructions : undefined
+  const imageUrl = typeof payload.imageUrl === "string" ? payload.imageUrl : undefined
+  const hotspots = sanitizeHotspots(payload.hotspots)
+  const assignmentId = typeof payload.assignmentId === "string" ? payload.assignmentId : undefined
+
+  if (!dueAt) {
+    return NextResponse.json({ error: "A valid due date is required" }, { status: 400 })
+  }
+
+  if (assignmentId) {
+    const existing = getTeacherAssignment(session.userId, assignmentId)
+    if (!existing) {
+      return NextResponse.json({ error: "Assignment not found" }, { status: 404 })
+    }
+  }
+
+  try {
+    const summary = createTeacherAssignment(session.userId, {
+      title,
+      description,
+      instructions,
+      assignmentType,
+      surahName,
+      surahNumber,
+      ayahRange,
+      dueAt,
+      classIds,
+      studentIds,
+      imageUrl,
+      hotspots,
+      status,
+    })
+
+    if (assignmentId) {
+      deleteTeacherAssignment(session.userId, assignmentId)
+    }
+
+    return NextResponse.json({ assignment: serializeAssignment(summary) })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unable to create assignment"
+    const statusCode = message.toLowerCase().includes("select at least one student") ? 422 : 400
+    return NextResponse.json({ error: message }, { status: statusCode })
+  }
+}

--- a/lib/data/teacher-database.ts
+++ b/lib/data/teacher-database.ts
@@ -1,4 +1,5 @@
 import { expandVerseRange, normalizeVerseKey, validateVerseKeys } from "../verse-validator"
+import { getVerseText } from "../quran-data"
 
 export type TeacherRole = "head" | "assistant"
 
@@ -111,6 +112,91 @@ export interface RecitationTaskRecord {
   submittedAt?: string
   reviewedAt?: string
   reviewNotes?: string
+  assignmentId?: string
+}
+
+export type AssignmentStatus = "draft" | "published" | "archived"
+
+export type AssignmentSubmissionStatus = "not_started" | "submitted" | "reviewed"
+
+export interface AssignmentHotspotRecord {
+  id: string
+  title: string
+  description: string
+  x: number
+  y: number
+  width: number
+  height: number
+  audioUrl?: string
+}
+
+export interface TeacherAssignmentRecord {
+  id: string
+  teacherId: string
+  title: string
+  description?: string
+  instructions?: string
+  assignmentType: string
+  surahName: string
+  surahNumber: number
+  ayahRange: string
+  dueDate: string
+  status: AssignmentStatus
+  createdAt: string
+  updatedAt: string
+  classIds: string[]
+  studentIds: string[]
+  imageUrl?: string
+  hotspots: AssignmentHotspotRecord[]
+}
+
+export interface AssignmentSubmissionRecord {
+  id: string
+  assignmentId: string
+  studentId: string
+  status: AssignmentSubmissionStatus
+  submittedAt?: string
+  reviewedAt?: string
+  score?: number
+  recitationTaskId?: string
+  notes?: string
+  updatedAt: string
+}
+
+export interface AssignmentWithStats {
+  assignment: TeacherAssignmentRecord
+  stats: {
+    assignedStudents: number
+    submitted: number
+    reviewed: number
+  }
+  submissions: AssignmentSubmissionRecord[]
+}
+
+export interface AssignmentHotspotInput {
+  title: string
+  description: string
+  x: number
+  y: number
+  width: number
+  height: number
+  audioUrl?: string
+}
+
+export interface CreateTeacherAssignmentInput {
+  title: string
+  description?: string
+  instructions?: string
+  assignmentType: string
+  surahName: string
+  surahNumber: number
+  ayahRange: string
+  dueAt: string
+  classIds: string[]
+  studentIds: string[]
+  imageUrl?: string
+  hotspots?: AssignmentHotspotInput[]
+  status?: AssignmentStatus
 }
 
 export interface RecitationSessionRecord {
@@ -506,6 +592,8 @@ interface TeacherDatabaseSchema {
   memorizationPlans: MemorizationPlanRecord[]
   studentMemorizationProgress: StudentMemorizationProgressRecord[]
   memorizationCompletions: MemorizationCompletionLogEntry[]
+  assignments: TeacherAssignmentRecord[]
+  assignmentSubmissions: AssignmentSubmissionRecord[]
 }
 
 const now = new Date()
@@ -524,6 +612,8 @@ const MAX_GAMIFICATION_LOG = 100
 const MEMORIZATION_REPETITION_TARGET = 20
 const MAX_MEMORIZATION_COMPLETIONS = 100
 const PLAN_CREATION_DAILY_LIMIT = 10
+
+let assignmentSequence = 0
 
 const database: TeacherDatabaseSchema = {
   teachers: [
@@ -587,7 +677,11 @@ const database: TeacherDatabaseSchema = {
     },
   ],
   memorizationCompletions: [],
+  assignments: [],
+  assignmentSubmissions: [],
 }
+
+assignmentSequence = database.assignments.length
 
 const planCreationTracker = new Map<string, { date: string; count: number }>()
 let planSequence = 0
@@ -607,6 +701,11 @@ function generateLearnerId(prefix: string): string {
     candidate = `${prefix}_${counter.toString().padStart(3, "0")}`
   }
   return candidate
+}
+
+function generateAssignmentId(): string {
+  assignmentSequence += 1
+  return `assignment_${assignmentSequence.toString().padStart(3, "0")}`
 }
 
 function createEmptyDashboardRecord(
@@ -1494,6 +1593,40 @@ function cloneLearnerState(record: LearnerRecord): LearnerState {
   }
 }
 
+function cloneAssignmentRecord(assignment: TeacherAssignmentRecord): TeacherAssignmentRecord {
+  return {
+    ...assignment,
+    classIds: [...assignment.classIds],
+    studentIds: [...assignment.studentIds],
+    hotspots: assignment.hotspots.map((hotspot) => ({ ...hotspot })),
+  }
+}
+
+function cloneAssignmentSubmission(submission: AssignmentSubmissionRecord): AssignmentSubmissionRecord {
+  return { ...submission }
+}
+
+function listAssignmentSubmissions(assignmentId: string): AssignmentSubmissionRecord[] {
+  return database.assignmentSubmissions
+    .filter((submission) => submission.assignmentId === assignmentId)
+    .map((submission) => cloneAssignmentSubmission(submission))
+}
+
+function buildAssignmentWithStats(assignment: TeacherAssignmentRecord): AssignmentWithStats {
+  const submissions = listAssignmentSubmissions(assignment.id)
+  const submitted = submissions.filter((entry) => entry.status !== "not_started").length
+  const reviewed = submissions.filter((entry) => entry.status === "reviewed").length
+  return {
+    assignment: cloneAssignmentRecord(assignment),
+    stats: {
+      assignedStudents: assignment.studentIds.length,
+      submitted,
+      reviewed,
+    },
+    submissions,
+  }
+}
+
 function getLearnerRecord(studentId: string): LearnerRecord | undefined {
   return database.learners[studentId]
 }
@@ -1922,6 +2055,25 @@ function parseAyahCount(range: string) {
   return Math.max(1, end - start + 1)
 }
 
+function parseAyahRangeInput(range: string): { start: number; end: number } {
+  const normalized = range.replace(/\s/g, "")
+  if (!normalized) {
+    throw new Error("Ayah range is required")
+  }
+  const [startPart, endPart] = normalized.split("-")
+  const start = Number.parseInt(startPart ?? "", 10)
+  if (!Number.isFinite(start) || start < 1) {
+    throw new Error("Invalid ayah range")
+  }
+  const end = endPart ? Number.parseInt(endPart, 10) : start
+  if (!Number.isFinite(end) || end < 1) {
+    throw new Error("Invalid ayah range")
+  }
+  const normalizedStart = Math.min(start, end)
+  const normalizedEnd = Math.max(start, end)
+  return { start: normalizedStart, end: normalizedEnd }
+}
+
 function recalculateRecitationAccuracy(record: LearnerRecord) {
   const sessions = record.dashboard.recitationSessions.slice(0, 10)
   if (sessions.length === 0) {
@@ -2253,6 +2405,199 @@ export function suggestMemorizationPlans(teacherId: string): SuggestedMemorizati
   }
 
   return suggestions
+}
+
+function resolveAssignmentStudents(
+  teacherId: string,
+  classIds: string[],
+  studentIds: string[],
+): { classIds: string[]; studentIds: string[] } {
+  const normalizedClasses = Array.from(new Set(classIds.map((id) => id.trim()).filter(Boolean)))
+  if (normalizedClasses.length > 0) {
+    assertTeacherOwnsClasses(teacherId, normalizedClasses)
+  }
+
+  const resolvedStudents = new Set<string>()
+  normalizedClasses.forEach((classId) => {
+    const classRecord = getClassRecord(classId)
+    classRecord?.studentIds.forEach((studentId) => resolvedStudents.add(studentId))
+  })
+
+  const normalizedStudents = Array.from(new Set(studentIds.map((id) => id.trim()).filter(Boolean)))
+  normalizedStudents.forEach((studentId) => {
+    if (database.learners[studentId]) {
+      resolvedStudents.add(studentId)
+    }
+  })
+
+  return { classIds: normalizedClasses, studentIds: Array.from(resolvedStudents) }
+}
+
+export function createTeacherAssignment(
+  teacherId: string,
+  input: CreateTeacherAssignmentInput,
+): AssignmentWithStats {
+  const title = input.title.trim()
+  if (!title) {
+    throw new Error("Assignment title is required")
+  }
+
+  if (!Number.isFinite(input.surahNumber) || input.surahNumber < 1) {
+    throw new Error("Please choose a valid surah")
+  }
+
+  const dueDate = new Date(input.dueAt)
+  if (Number.isNaN(dueDate.getTime())) {
+    throw new Error("A valid due date is required")
+  }
+
+  const status: AssignmentStatus = input.status ?? "draft"
+  const { start, end } = parseAyahRangeInput(input.ayahRange)
+  const verseKeys = expandVerseRange(input.surahNumber, start, end)
+
+  const { classIds, studentIds } = resolveAssignmentStudents(teacherId, input.classIds, input.studentIds)
+  if (status === "published" && studentIds.length === 0) {
+    throw new Error("Select at least one student or class before publishing")
+  }
+
+  const nowDate = new Date()
+  const assignmentId = generateAssignmentId()
+  const hotspots = (input.hotspots ?? []).map((hotspot, index) => ({
+    id: `${assignmentId}_hotspot_${index + 1}`,
+    title: hotspot.title.trim() || `Hotspot ${index + 1}`,
+    description: hotspot.description.trim(),
+    x: Math.max(0, Math.min(100, hotspot.x)),
+    y: Math.max(0, Math.min(100, hotspot.y)),
+    width: Math.max(0, Math.min(100, hotspot.width)),
+    height: Math.max(0, Math.min(100, hotspot.height)),
+    audioUrl: hotspot.audioUrl?.trim() || undefined,
+  }))
+
+  const assignment: TeacherAssignmentRecord = {
+    id: assignmentId,
+    teacherId,
+    title,
+    description: input.description?.trim() || undefined,
+    instructions: input.instructions?.trim() || undefined,
+    assignmentType: input.assignmentType,
+    surahName: input.surahName,
+    surahNumber: input.surahNumber,
+    ayahRange: `${start}-${end}`,
+    dueDate: dueDate.toISOString(),
+    status,
+    createdAt: iso(nowDate),
+    updatedAt: iso(nowDate),
+    classIds,
+    studentIds,
+    imageUrl: input.imageUrl,
+    hotspots,
+  }
+
+  database.assignments.unshift(assignment)
+
+  if (assignment.status === "published") {
+    const verseRecords: RecitationVerseRecord[] = verseKeys.map((key) => {
+      const [surahPart, ayahPart] = key.split(":")
+      const ayah = Number.parseInt(ayahPart ?? "", 10)
+      return {
+        ayah: Number.isFinite(ayah) ? ayah : 0,
+        arabic: getVerseText(key),
+        translation: "",
+      }
+    })
+
+    const notes = assignment.instructions || assignment.description || `Complete ${assignment.surahName}`
+
+    assignment.studentIds.forEach((studentId) => {
+      const learner = getLearnerRecord(studentId)
+      if (!learner) {
+        return
+      }
+
+      const taskId = `${assignment.id}__${studentId}`
+      const existingTask = learner.dashboard.recitationTasks.find((task) => task.id === taskId)
+      if (!existingTask) {
+        const task: RecitationTaskRecord = {
+          id: taskId,
+          surah: assignment.surahName,
+          ayahRange: assignment.ayahRange,
+          dueDate: assignment.dueDate,
+          status: "assigned",
+          targetAccuracy: 90,
+          teacherId,
+          notes,
+          assignedAt: assignment.createdAt,
+          focusAreas: undefined,
+          verses: verseRecords,
+          assignmentId: assignment.id,
+        }
+        learner.dashboard.recitationTasks.unshift(task)
+      }
+
+      const submissionId = `${assignment.id}__${studentId}`
+      const submission: AssignmentSubmissionRecord = {
+        id: submissionId,
+        assignmentId: assignment.id,
+        studentId,
+        status: "not_started",
+        updatedAt: iso(nowDate),
+        recitationTaskId: taskId,
+      }
+
+      const existingSubmissionIndex = database.assignmentSubmissions.findIndex(
+        (entry) => entry.id === submissionId,
+      )
+      if (existingSubmissionIndex === -1) {
+        database.assignmentSubmissions.push(submission)
+      } else {
+        database.assignmentSubmissions[existingSubmissionIndex] = submission
+      }
+    })
+  }
+
+  return buildAssignmentWithStats(assignment)
+}
+
+export function listTeacherAssignments(teacherId: string): AssignmentWithStats[] {
+  return database.assignments
+    .filter((assignment) => assignment.teacherId === teacherId)
+    .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime())
+    .map((assignment) => buildAssignmentWithStats(assignment))
+}
+
+export function getTeacherAssignment(
+  teacherId: string,
+  assignmentId: string,
+): AssignmentWithStats | undefined {
+  const assignment = database.assignments.find(
+    (candidate) => candidate.teacherId === teacherId && candidate.id === assignmentId,
+  )
+  if (!assignment) {
+    return undefined
+  }
+  return buildAssignmentWithStats(assignment)
+}
+
+export function deleteTeacherAssignment(teacherId: string, assignmentId: string): boolean {
+  const index = database.assignments.findIndex(
+    (assignment) => assignment.id === assignmentId && assignment.teacherId === teacherId,
+  )
+  if (index === -1) {
+    return false
+  }
+
+  database.assignments.splice(index, 1)
+  database.assignmentSubmissions = database.assignmentSubmissions.filter(
+    (submission) => submission.assignmentId !== assignmentId,
+  )
+
+  Object.values(database.learners).forEach((learner) => {
+    learner.dashboard.recitationTasks = learner.dashboard.recitationTasks.filter(
+      (task) => task.assignmentId !== assignmentId,
+    )
+  })
+
+  return true
 }
 
 export function listStudentMemorizationPlans(
@@ -2715,6 +3060,19 @@ export function logRecitationSession(
       task.status = "submitted"
     }
     task.reviewNotes = `Awaiting instructor review. Auto-score ${session.accuracy}% accuracy.`
+
+    if (task.assignmentId) {
+      const submission = database.assignmentSubmissions.find(
+        (entry) => entry.assignmentId === task.assignmentId && entry.studentId === studentId,
+      )
+      if (submission) {
+        submission.status = "submitted"
+        submission.submittedAt = session.submittedAt
+        submission.updatedAt = session.submittedAt
+        submission.score = session.accuracy
+        submission.recitationTaskId = task.id
+      }
+    }
   }
 
   const ayahCount = parseAyahCount(submission.ayahRange)
@@ -2954,6 +3312,21 @@ export function reviewRecitationTask(
     task.submittedAt = iso(nowDate)
   }
   task.teacherId = review.teacherId
+
+  if (task.assignmentId) {
+    const submission = database.assignmentSubmissions.find(
+      (entry) => entry.assignmentId === task.assignmentId && entry.studentId === studentId,
+    )
+    if (submission) {
+      submission.status = "reviewed"
+      submission.score = normalizedAccuracy
+      submission.submittedAt = submission.submittedAt ?? task.submittedAt
+      submission.reviewedAt = task.reviewedAt
+      submission.updatedAt = iso(nowDate)
+      submission.notes = review.notes ?? submission.notes
+      submission.recitationTaskId = task.id
+    }
+  }
 
   const relatedSession = record.dashboard.recitationSessions.find((session) => session.taskId === task.id)
   if (relatedSession) {


### PR DESCRIPTION
## Summary
- add assignment data models, creation helpers, and submission tracking to the in-memory teacher database
- expose a teacher assignments API endpoint that validates input, supports draft republishing, and returns serialized summaries
- wire the teacher assignment creation UI to the API with form validation, toast feedback, and updated class/surah options

## Testing
- npm run lint *(fails: requires @eslint/eslintrc package in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e46fb5931083278a3ed62f9292dd17