### PR TITLE
Update localhost references to port 3001

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Core web app configuration
-NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=http://localhost:3001
 
 # Paystack credentials for payments API routes
 PAYSTACK_SECRET_KEY=sk_test_change_me

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ hooks/
    ```bash
    npm run rundev
    ```
-   Visit `http://localhost:3000` to explore the dashboards and Habit Quest Arena.
+   Visit `http://localhost:3001` to explore the dashboards and Habit Quest Arena.
 3. **Run lint checks**
    ```bash
    npm run lint


### PR DESCRIPTION
## Summary
- update the example environment URL to use http://localhost:3001
- adjust the README getting started instructions to point to the new port

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e476aaf010832799f39e96c72a670f