### PR TITLE
Configure development server to run on port 3001

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "next build",
     "build:standalone": "npm run build",
-    "dev": "next dev",
+    "dev": "next dev -p 3001",
     "lint": "eslint . --max-warnings=0",
     "rundev": "npm run dev",
     "start": "npm run build && next start -p 3001",


### PR DESCRIPTION
## Summary
- update the Next.js development script to run on port 3001 so the app serves from http://localhost:3001/

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4773b26388327b94f78de6bde6827