### PR TITLE
Prevent advancing memorization before meeting repetition target

### DIFF
--- a/hooks/useMemorizationProgress.ts
+++ b/hooks/useMemorizationProgress.ts
@@ -103,6 +103,19 @@ export function useMemorizationProgress({
     if (isAdvancing) {
       return
     }
+    if (progress.completedAt) {
+      setVerseCelebrationOpen(false)
+      return
+    }
+    if (progress.repetitionsDone < REPETITION_TARGET) {
+      toast({
+        title: "Keep repeating",
+        description: `Complete ${REPETITION_TARGET} repetitions before advancing.`,
+        variant: "default",
+      })
+      setVerseCelebrationOpen(false)
+      return
+    }
     setIsAdvancing(true)
     try {
       const updated = await advanceMemorizationVerse(plan.id)


### PR DESCRIPTION
## Summary
- guard the client-side advance handler so we only call the API after finishing the required repetitions
- close the celebration modal and show a gentle reminder toast instead of sending invalid advance requests

## Testing
- Not run (client-side change only)


------
https://chatgpt.com/codex/tasks/task_e_68e47ddd35dc8327b151a8b19388201e