### PR TITLE
Add celebration and overflow tracking for daily ayah goal

### DIFF
--- a/lib/data/teacher-database.ts
+++ b/lib/data/teacher-database.ts
@@ -2856,10 +2856,7 @@ export function recordAyahProgress(studentId: string, increment = 1): LearnerSta
   }
 
   const previousCompleted = record.dashboard.dailyTarget.completedAyahs
-  const nextCompleted = Math.min(
-    previousCompleted + normalizedIncrement,
-    record.dashboard.dailyTarget.targetAyahs,
-  )
+  const nextCompleted = previousCompleted + normalizedIncrement
   const actualIncrement = Math.max(0, nextCompleted - previousCompleted)
 
   record.dashboard.dailyTarget.completedAyahs = nextCompleted


### PR DESCRIPTION
## Summary
- trigger a celebratory modal with a confetti shower when the reader hits the daily ayah target while keeping the session going
- surface total ayahs recited in the modal so learners know progress beyond the goal is recorded for dashboards
- let ayah progress persistence record counts beyond the target so additional recitation updates learner and teacher analytics

## Testing
- npm run lint *(fails: repository currently has pre-existing lint violations across untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e483c0cb948327a38c1babd17b7be7