### PR TITLE
Add teacher roster pages and enhance assignment workflow

### DIFF
--- a/app/api/teacher/students/route.ts
+++ b/app/api/teacher/students/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server"
+
+import { getActiveSession } from "@/lib/data/auth"
+import { listStudentsForTeacher } from "@/lib/data/teacher-database"
+
+export function GET() {
+  const session = getActiveSession()
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  if (session.role !== "teacher") {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+  }
+
+  const students = listStudentsForTeacher(session.userId).map((student) => ({
+    ...student,
+    classIds: [...student.classIds],
+    classNames: [...student.classNames],
+  }))
+
+  return NextResponse.json({ students })
+}

--- a/app/teacher/classes/page.tsx
+++ b/app/teacher/classes/page.tsx
@@ -1,0 +1,126 @@
+import { redirect } from "next/navigation"
+
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { getActiveSession } from "@/lib/data/auth"
+import { listClassesForTeacher, listStudentsForTeacher } from "@/lib/data/teacher-database"
+
+export default function TeacherClassesPage() {
+  const session = getActiveSession()
+  if (!session) {
+    redirect("/auth/sign-in")
+  }
+  if (session.role !== "teacher") {
+    redirect("/dashboard")
+  }
+
+  const classes = listClassesForTeacher(session.userId)
+  const students = listStudentsForTeacher(session.userId)
+  const studentsById = new Map(students.map((student) => [student.id, student]))
+
+  const totalStudents = classes.reduce((total, classRecord) => total + classRecord.studentCount, 0)
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-8 px-4 py-10">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Classes & Cohorts</h1>
+        <p className="text-muted-foreground">
+          Review each learning circle, its schedule, and the students assigned to you.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card className="border-border/60">
+          <CardHeader>
+            <CardTitle className="text-sm font-medium text-muted-foreground">Total Classes</CardTitle>
+            <CardDescription className="text-3xl font-semibold text-foreground">{classes.length}</CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="border-border/60">
+          <CardHeader>
+            <CardTitle className="text-sm font-medium text-muted-foreground">Learners Assigned</CardTitle>
+            <CardDescription className="text-3xl font-semibold text-foreground">{totalStudents}</CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="border-border/60">
+          <CardHeader>
+            <CardTitle className="text-sm font-medium text-muted-foreground">Average Class Size</CardTitle>
+            <CardDescription className="text-3xl font-semibold text-foreground">
+              {classes.length === 0 ? 0 : Math.round(totalStudents / classes.length)}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+
+      {classes.length === 0 ? (
+        <Card className="border-border/60">
+          <CardContent className="py-10 text-center text-muted-foreground">
+            You don&apos;t have any classes yet. Create a class to begin assigning memorization plans and tasks.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-6">
+          {classes.map((classRecord) => (
+            <Card key={classRecord.id} className="border-border/60">
+              <CardHeader className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <CardTitle className="text-2xl font-semibold">{classRecord.name}</CardTitle>
+                  <CardDescription>{classRecord.description ?? "No description has been added yet."}</CardDescription>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Badge variant="secondary">{classRecord.schedule ?? "Schedule coming soon"}</Badge>
+                  <Badge variant="outline">{classRecord.studentCount} students</Badge>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div>
+                  <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">Enrolled Students</h3>
+                  <Separator className="my-3" />
+                  {classRecord.studentIds.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">
+                      No students have been added to this class yet.
+                    </p>
+                  ) : (
+                    <div className="grid gap-3 md:grid-cols-2">
+                      {classRecord.studentIds.map((studentId) => {
+                        const student = studentsById.get(studentId)
+                        if (!student) {
+                          return null
+                        }
+                        return (
+                          <div
+                            key={student.id}
+                            className="rounded-lg border border-border/50 bg-background/80 p-4 shadow-sm"
+                          >
+                            <div className="flex items-center justify-between">
+                              <div>
+                                <p className="text-base font-semibold">{student.name}</p>
+                                <p className="text-xs text-muted-foreground">{student.email}</p>
+                              </div>
+                              <Badge variant="outline">{student.streak} day streak</Badge>
+                            </div>
+                            <div className="mt-3 grid grid-cols-2 gap-3 text-sm">
+                              <div>
+                                <p className="text-muted-foreground">Memorization</p>
+                                <p className="font-semibold">{student.memorizationProgress}%</p>
+                              </div>
+                              <div>
+                                <p className="text-muted-foreground">Recitation</p>
+                                <p className="font-semibold">{student.recitationProgress}%</p>
+                              </div>
+                            </div>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/app/teacher/reports/page.tsx
+++ b/app/teacher/reports/page.tsx
@@ -1,0 +1,175 @@
+import { redirect } from "next/navigation"
+
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { getActiveSession } from "@/lib/data/auth"
+import { getInstructorDashboardSummary } from "@/lib/data/teacher-database"
+
+export default function TeacherReportsPage() {
+  const session = getActiveSession()
+  if (!session) {
+    redirect("/auth/sign-in")
+  }
+  if (session.role !== "teacher") {
+    redirect("/dashboard")
+  }
+
+  const summary = getInstructorDashboardSummary(session.userId)
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-8 px-4 py-10">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Progress & Reports</h1>
+        <p className="text-muted-foreground">
+          Real-time insight into learner momentum, assignment completion, and gamified engagement across your classes.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-4">
+        <Card className="border-border/60">
+          <CardHeader>
+            <CardTitle className="text-sm font-medium text-muted-foreground">Total Students</CardTitle>
+            <CardDescription className="text-3xl font-semibold text-foreground">
+              {summary.classStats.totalStudents}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="border-border/60">
+          <CardHeader>
+            <CardTitle className="text-sm font-medium text-muted-foreground">Active in Last 24h</CardTitle>
+            <CardDescription className="text-3xl font-semibold text-foreground">
+              {summary.classStats.activeStudents}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="border-border/60">
+          <CardHeader>
+            <CardTitle className="text-sm font-medium text-muted-foreground">Assignments Reviewed</CardTitle>
+            <CardDescription className="text-3xl font-semibold text-foreground">
+              {summary.classStats.completedAssignments}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="border-border/60">
+          <CardHeader>
+            <CardTitle className="text-sm font-medium text-muted-foreground">Avg. Recitation Accuracy</CardTitle>
+            <CardDescription className="text-3xl font-semibold text-foreground">
+              {summary.classStats.averageProgress}%
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <Card className="border-border/60">
+          <CardHeader>
+            <CardTitle>Recent Assignments</CardTitle>
+            <CardDescription>Track delivery and submissions at a glance.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {summary.recentAssignments.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No assignments have been issued yet.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Assignment</TableHead>
+                    <TableHead className="text-right">Due Date</TableHead>
+                    <TableHead className="text-right">Status</TableHead>
+                    <TableHead className="text-right">Submissions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {summary.recentAssignments.map((assignment) => (
+                    <TableRow key={assignment.id}>
+                      <TableCell>
+                        <div className="flex flex-col">
+                          <span className="font-medium">{assignment.title}</span>
+                          <span className="text-xs text-muted-foreground">{assignment.className}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-right text-sm text-muted-foreground">
+                        {new Date(assignment.dueDate).toLocaleDateString()}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Badge variant={assignment.status === "reviewed" ? "default" : "secondary"}>
+                          {assignment.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {assignment.submitted}/{assignment.total}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/60">
+          <CardHeader>
+            <CardTitle>Top Student Progress</CardTitle>
+            <CardDescription>Recognize momentum and offer timely encouragement.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {summary.studentProgress.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No student activity has been recorded yet.</p>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Learner</TableHead>
+                    <TableHead className="text-right">Memorization</TableHead>
+                    <TableHead className="text-right">Streak</TableHead>
+                    <TableHead className="text-right">Recitation</TableHead>
+                    <TableHead className="text-right">Last Active</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {summary.studentProgress.map((student) => (
+                    <TableRow key={student.id}>
+                      <TableCell>{student.name}</TableCell>
+                      <TableCell className="text-right">{student.progress}%</TableCell>
+                      <TableCell className="text-right">{student.streak}</TableCell>
+                      <TableCell className="text-right">{student.recitationAccuracy}%</TableCell>
+                      <TableCell className="text-right text-sm text-muted-foreground">{student.lastActive}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card className="border-border/60">
+        <CardHeader>
+          <CardTitle>Gamification Snapshot</CardTitle>
+          <CardDescription>Understand how your learners are interacting with Alfawz missions.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-4 md:grid-cols-4">
+            <div className="rounded-lg border border-border/50 p-4">
+              <p className="text-sm text-muted-foreground">Completed Tasks</p>
+              <p className="text-2xl font-semibold">{summary.gamification.completedTasks}</p>
+            </div>
+            <div className="rounded-lg border border-border/50 p-4">
+              <p className="text-sm text-muted-foreground">Pending Tasks</p>
+              <p className="text-2xl font-semibold">{summary.gamification.pendingTasks}</p>
+            </div>
+            <div className="rounded-lg border border-border/50 p-4">
+              <p className="text-sm text-muted-foreground">Active Boosts</p>
+              <p className="text-2xl font-semibold">{summary.gamification.activeBoosts}</p>
+            </div>
+            <div className="rounded-lg border border-border/50 p-4">
+              <p className="text-sm text-muted-foreground">Average Season Level</p>
+              <p className="text-2xl font-semibold">{summary.gamification.averageSeasonLevel}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </main>
+  )
+}

--- a/app/teacher/students/page.tsx
+++ b/app/teacher/students/page.tsx
@@ -1,0 +1,167 @@
+import { redirect } from "next/navigation"
+
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import { getActiveSession } from "@/lib/data/auth"
+import { listClassesForTeacher, listStudentsForTeacher } from "@/lib/data/teacher-database"
+
+function formatDateLabel(timestamp?: string | null) {
+  if (!timestamp) {
+    return "No activity yet"
+  }
+
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) {
+    return "No activity yet"
+  }
+
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date)
+}
+
+export default function TeacherStudentsPage() {
+  const session = getActiveSession()
+  if (!session) {
+    redirect("/auth/sign-in")
+  }
+  if (session.role !== "teacher") {
+    redirect("/dashboard")
+  }
+
+  const students = listStudentsForTeacher(session.userId)
+  const classes = listClassesForTeacher(session.userId)
+
+  const totalStudents = students.length
+  const averageMemorization =
+    totalStudents === 0
+      ? 0
+      : Math.round(
+          students.reduce((total, student) => total + student.memorizationProgress, 0) / totalStudents,
+        )
+  const averageRecitation =
+    totalStudents === 0
+      ? 0
+      : Math.round(students.reduce((total, student) => total + student.recitationProgress, 0) / totalStudents)
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-8 px-4 py-10">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Student Roster</h1>
+        <p className="text-muted-foreground">
+          Monitor every learner assigned to your classes and review their memorization momentum at a glance.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card className="border-border/60">
+          <CardHeader>
+            <CardTitle className="text-sm font-medium text-muted-foreground">Active Students</CardTitle>
+            <CardDescription className="text-3xl font-semibold text-foreground">{totalStudents}</CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="border-border/60">
+          <CardHeader>
+            <CardTitle className="text-sm font-medium text-muted-foreground">Avg. Memorization Progress</CardTitle>
+            <CardDescription className="text-3xl font-semibold text-foreground">{averageMemorization}%</CardDescription>
+          </CardHeader>
+        </Card>
+        <Card className="border-border/60">
+          <CardHeader>
+            <CardTitle className="text-sm font-medium text-muted-foreground">Avg. Recitation Accuracy</CardTitle>
+            <CardDescription className="text-3xl font-semibold text-foreground">{averageRecitation}%</CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+
+      <Card className="border-border/60">
+        <CardHeader>
+          <CardTitle>Students</CardTitle>
+          <CardDescription>
+            Each learner is automatically grouped by the classes you oversee so you can follow-up with ease.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {students.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No students are assigned to your classes yet.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Classes</TableHead>
+                    <TableHead className="text-right">Streak</TableHead>
+                    <TableHead className="text-right">Hasanat</TableHead>
+                    <TableHead className="text-right">Memorization</TableHead>
+                    <TableHead className="text-right">Recitation</TableHead>
+                    <TableHead className="text-right">Last Active</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {students.map((student) => (
+                    <TableRow key={student.id}>
+                      <TableCell className="font-medium">
+                        <div className="flex flex-col">
+                          <span>{student.name}</span>
+                          <span className="text-xs text-muted-foreground">{student.email}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="max-w-[220px]">
+                        <div className="flex flex-wrap gap-1">
+                          {student.classNames.map((className, index) => (
+                            <Badge key={`${student.id}-${student.classIds[index]}`} variant="secondary">
+                              {className}
+                            </Badge>
+                          ))}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-right">{student.streak} days</TableCell>
+                      <TableCell className="text-right">{student.hasanat}</TableCell>
+                      <TableCell className="text-right">{student.memorizationProgress}%</TableCell>
+                      <TableCell className="text-right">{student.recitationProgress}%</TableCell>
+                      <TableCell className="text-right text-sm text-muted-foreground">
+                        {formatDateLabel(student.lastActiveAt)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="border-border/60">
+        <CardHeader>
+          <CardTitle>Your Classes</CardTitle>
+          <CardDescription>Quick summary of the cohorts you&apos;re currently supporting.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {classes.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No classes have been created for this instructor yet.</p>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2">
+              {classes.map((classRecord) => (
+                <div key={classRecord.id} className="rounded-lg border border-border/60 p-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h3 className="text-base font-semibold">{classRecord.name}</h3>
+                      <p className="text-sm text-muted-foreground">{classRecord.description ?? "No description yet."}</p>
+                    </div>
+                    <Badge variant="outline">{classRecord.studentCount} students</Badge>
+                  </div>
+                  {classRecord.schedule && (
+                    <p className="mt-3 text-sm text-muted-foreground">Schedule: {classRecord.schedule}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </main>
+  )
+}

--- a/components/hotspot-editor.tsx
+++ b/components/hotspot-editor.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { Trash2, Play, Pause, Upload, Save } from "lucide-react"
+import { Trash2, Play, Pause, Save, Mic } from "lucide-react"
 
 interface Hotspot {
   id: string
@@ -108,6 +108,11 @@ export function HotspotEditor({ imageUrl, hotspots, onHotspotsChange, mode }: Ho
   }
 
   const startRecording = async () => {
+    if (!selectedHotspot) {
+      console.warn("Select a hotspot before recording audio")
+      return
+    }
+
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
       const mediaRecorder = new MediaRecorder(stream)
@@ -357,6 +362,12 @@ export function HotspotEditor({ imageUrl, hotspots, onHotspotsChange, mode }: Ho
                             className={
                               isRecording ? "bg-red-600 hover:bg-red-700" : "bg-maroon-600 hover:bg-maroon-700"
                             }
+                            disabled={!selectedHotspot}
+                            title={
+                              selectedHotspot
+                                ? undefined
+                                : "Select a hotspot from the list before recording voice notes"
+                            }
                           >
                             {isRecording ? (
                               <>
@@ -365,7 +376,7 @@ export function HotspotEditor({ imageUrl, hotspots, onHotspotsChange, mode }: Ho
                               </>
                             ) : (
                               <>
-                                <Upload className="w-4 h-4 mr-1" />
+                                <Mic className="w-4 h-4 mr-1" />
                                 Record Audio
                               </>
                             )}

--- a/lib/data/teacher-database.ts
+++ b/lib/data/teacher-database.ts
@@ -473,6 +473,19 @@ export interface TeacherClassSummary {
   studentCount: number
 }
 
+export interface TeacherStudentSummary {
+  id: string
+  name: string
+  email: string
+  classIds: string[]
+  classNames: string[]
+  streak: number
+  hasanat: number
+  memorizationProgress: number
+  recitationProgress: number
+  lastActiveAt?: string | null
+}
+
 export interface TeacherMemorizationPlanStats {
   verseCount: number
   assignedStudents: number
@@ -2166,6 +2179,55 @@ export function getMemorizationClasses(): ClassRecord[] {
 
 export function listClassesForTeacher(teacherId: string): TeacherClassSummary[] {
   return getTeacherClassRecords(teacherId).map((classRecord) => cloneTeacherClassSummary(classRecord))
+}
+
+export function listStudentsForTeacher(teacherId: string): TeacherStudentSummary[] {
+  const classes = getTeacherClassRecords(teacherId)
+  const classMap = new Map(classes.map((classRecord) => [classRecord.id, classRecord]))
+
+  const studentsById = new Map<string, Set<string>>()
+  classes.forEach((classRecord) => {
+    classRecord.studentIds.forEach((studentId) => {
+      if (!studentsById.has(studentId)) {
+        studentsById.set(studentId, new Set())
+      }
+      studentsById.get(studentId)?.add(classRecord.id)
+    })
+  })
+
+  const summaries: TeacherStudentSummary[] = []
+
+  studentsById.forEach((classIds, studentId) => {
+    const learner = getLearnerRecord(studentId)
+    if (!learner) {
+      return
+    }
+
+    const sortedClassIds = Array.from(classIds)
+    sortedClassIds.sort((a, b) => {
+      const aName = classMap.get(a)?.name ?? ""
+      const bName = classMap.get(b)?.name ?? ""
+      return aName.localeCompare(bName)
+    })
+
+    const lastActivity = learner.dashboard.activities[0]?.timestamp ?? null
+
+    summaries.push({
+      id: learner.profile.id,
+      name: learner.profile.name,
+      email: learner.profile.email,
+      classIds: sortedClassIds,
+      classNames: sortedClassIds.map((classId) => classMap.get(classId)?.name ?? classId),
+      streak: learner.stats.streak,
+      hasanat: learner.stats.hasanat,
+      memorizationProgress: learner.dashboard.memorizationPercentage,
+      recitationProgress: learner.dashboard.recitationPercentage,
+      lastActiveAt: lastActivity,
+    })
+  })
+
+  summaries.sort((a, b) => a.name.localeCompare(b.name))
+  return summaries
 }
 
 export function listTeacherMemorizationPlans(


### PR DESCRIPTION
## Summary
- add dedicated teacher students, classes, and reports pages so dashboard links resolve with contextual data
- expose a teacher students API and supporting data helper for roster-aware UI components
- streamline assignment creation with recipient selection, device image uploads, and improved hotspot audio controls

## Testing
- npm run lint *(fails: existing lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e48597f5d8832796cd51c51aa027dc