### PR TITLE
Fix active memorization plan selection

### DIFF
--- a/app/api/memorization/current-plan/[id]/route.ts
+++ b/app/api/memorization/current-plan/[id]/route.ts
@@ -26,6 +26,7 @@ export function GET(_request: Request, { params }: RouteContext) {
       progress: planContext.progress,
       classes: planContext.classes.map(({ studentIds: _studentIds, ...rest }) => ({ ...rest })),
       teacher: planContext.teacher ? { ...planContext.teacher } : undefined,
+      isActive: planContext.isActive,
     },
   }
 

--- a/app/student/memorization/page.tsx
+++ b/app/student/memorization/page.tsx
@@ -1,9 +1,6 @@
 import { redirect } from "next/navigation"
 import { getActiveSession } from "@/lib/data/auth"
-import {
-  getStudentActiveMemorizationPlanId,
-  listStudentMemorizationPlans,
-} from "@/lib/data/teacher-database"
+import { listStudentMemorizationPlans } from "@/lib/data/teacher-database"
 import { StudentMemorizationDashboard } from "@/components/student/StudentMemorizationDashboard"
 import { formatVerseReference } from "@/lib/quran-data"
 
@@ -34,7 +31,8 @@ export default function StudentMemorizationPage() {
   const nudgePlan = assignedPlans.find((plan) => buildNudgeMessage(plan))
   const nudgeMessage = nudgePlan ? buildNudgeMessage(nudgePlan) : undefined
 
-  const activePlanId = getStudentActiveMemorizationPlanId(session.userId)
+  const activePlanId =
+    assignedPlans.find((context) => context.isActive)?.plan.id ?? assignedPlans[0]?.plan.id
 
   return (
     <div className="min-h-screen bg-amber-50/70 py-12">
@@ -48,6 +46,7 @@ export default function StudentMemorizationPage() {
               return { ...rest }
             }),
             teacher: context.teacher,
+            isActive: context.isActive,
           }))}
           nudgeMessage={nudgeMessage}
           initialActivePlanId={activePlanId}

--- a/components/student/StudentMemorizationDashboard.tsx
+++ b/components/student/StudentMemorizationDashboard.tsx
@@ -243,8 +243,10 @@ export function StudentMemorizationDashboard({
         try {
           const planContext = await createPersonalMemorizationPlan(payload)
           setPlans((prev) => {
-            const next = prev.filter((entry) => entry.plan.id !== planContext.plan.id)
-            return [planContext, ...next]
+            const next = prev
+              .filter((entry) => entry.plan.id !== planContext.plan.id)
+              .map((entry) => ({ ...entry, isActive: false }))
+            return [{ ...planContext, isActive: true }, ...next]
           })
           setActivePlanId(planContext.plan.id)
           toast({
@@ -270,8 +272,10 @@ export function StudentMemorizationDashboard({
       const { plan } = await setActiveMemorizationPlan(planId)
       setActivePlanId(plan.plan.id)
       setPlans((prev) => {
-        const remaining = prev.filter((entry) => entry.plan.id !== plan.plan.id)
-        return [plan, ...remaining]
+        const remaining = prev
+          .filter((entry) => entry.plan.id !== plan.plan.id)
+          .map((entry) => ({ ...entry, isActive: false }))
+        return [{ ...plan, isActive: true }, ...remaining]
       })
       toast({ title: "Focus updated", description: "This plan is now your primary habit." })
     } catch (error) {

--- a/lib/data/teacher-database.ts
+++ b/lib/data/teacher-database.ts
@@ -593,6 +593,7 @@ export interface StudentMemorizationPlanContext {
   progress: StudentMemorizationProgressRecord
   classes: ClassRecord[]
   teacher?: TeacherProfile
+  isActive: boolean
 }
 
 interface LearnerRecord {
@@ -2384,6 +2385,7 @@ export function createPersonalMemorizationPlan(
     progress: cloneProgressRecord(progress),
     classes: [cloneTeacherClassSummary(classRecord)],
     teacher: undefined,
+    isActive: true,
   }
 }
 
@@ -2800,6 +2802,8 @@ export function listStudentMemorizationPlans(
   studentId: string,
 ): StudentMemorizationPlanContext[] {
   ensureProgressRecordsForStudent(studentId)
+  const learner = getLearnerRecord(studentId)
+  const activePlanId = learner?.meta.activeMemorizationPlanId
   const accessiblePlans = database.memorizationPlans.filter((plan) =>
     studentHasAccessToPlan(studentId, plan),
   )
@@ -2821,6 +2825,7 @@ export function listStudentMemorizationPlans(
       progress: cloneProgressRecord(progress),
       classes,
       teacher: teacher ? { ...teacher } : undefined,
+      isActive: plan.id === activePlanId,
     }
   })
 }
@@ -2861,6 +2866,8 @@ export function getStudentMemorizationPlanContext(
   }
 
   const progress = ensureProgressRecordForPlan(studentId, plan)
+  const learner = getLearnerRecord(studentId)
+  const activePlanId = learner?.meta.activeMemorizationPlanId
   const classes = plan.classIds
     .map((classId) => getClassRecord(classId))
     .filter((classRecord): classRecord is ClassRecord => Boolean(classRecord))
@@ -2876,6 +2883,7 @@ export function getStudentMemorizationPlanContext(
     progress: cloneProgressRecord(progress),
     classes,
     teacher: teacher ? { ...teacher } : undefined,
+    isActive: plan.id === activePlanId,
   }
 }
 

--- a/lib/memorization-api.ts
+++ b/lib/memorization-api.ts
@@ -59,6 +59,7 @@ export interface StudentMemorizationPlanContextDTO {
   progress: StudentPlanProgressDTO
   classes: MemorizationClassSummary[]
   teacher?: TeacherSummaryDTO
+  isActive: boolean
 }
 
 export interface CreatePersonalPlanPayload {


### PR DESCRIPTION
## Summary
- include an `isActive` flag in student memorization plan contexts so the active focus can be derived without relying on the broken helper
- propagate the flag through the student memorization API routes and dashboard so plan creation and focus changes keep other plans inactive
- fall back to the first available plan when no active plan is set to prevent runtime crashes on the student memorization page

## Testing
- npm run lint *(fails: repository has numerous existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e4883bdf1c8327988b7bbf225c72bd