### PR TITLE
Ensure Flipbook Mushaf surahs available offline

### DIFF
--- a/components/quran-flipbook.tsx
+++ b/components/quran-flipbook.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { BookOpen, Bookmark, ChevronLeft, ChevronRight, Loader2 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { quranAPI, type Ayah, type Surah } from "@/lib/quran-api"
+import { getOfflineSurahList, quranAPI, type Ayah, type Surah } from "@/lib/quran-api"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -38,7 +38,7 @@ interface FocusedAyah {
 }
 
 export function QuranFlipBook({ initialSurahName, initialAyah, className }: QuranFlipBookProps) {
-  const [surahs, setSurahs] = useState<Surah[]>([])
+  const [surahs, setSurahs] = useState<Surah[]>(() => getOfflineSurahList())
   const [selectedSurah, setSelectedSurah] = useState<Surah | null>(null)
   const [pages, setPages] = useState<QuranPage[]>([])
   const [translationMap, setTranslationMap] = useState<Record<number, string>>({})
@@ -66,7 +66,9 @@ export function QuranFlipBook({ initialSurahName, initialAyah, className }: Qura
       try {
         const surahList = await quranAPI.getSurahs()
         if (!isMountedRef.current) return
-        setSurahs(surahList)
+        if (surahList.length > 0) {
+          setSurahs(surahList)
+        }
       } catch (error) {
         console.error("Failed to load surah list", error)
       }

--- a/lib/quran-api.ts
+++ b/lib/quran-api.ts
@@ -612,6 +612,10 @@ class QuranCloudAPI {
 // Export singleton instance
 export const quranAPI = new QuranCloudAPI()
 
+export function getOfflineSurahList(): Surah[] {
+  return fallbackSurahList.map((surah) => ({ ...surah }))
+}
+
 // Helper functions for common operations
 export async function getPopularSurahs(): Promise<Surah[]> {
   const allSurahs = await quranAPI.getSurahs()


### PR DESCRIPTION
## Summary
- seed the Flipbook Mushaf Explorer with the offline surah list so the dropdown always has options
- keep the offline list when remote fetches fail or return empty data
- expose a helper from the Quran API module to access the offline surah metadata

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e48c0435e083278bfd7b873113c160