### PR TITLE
Add React Native speech streaming utilities

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,56 @@
+# Mobile Speech Capture Utilities
+
+This directory contains React Native utilities that mirror the live tajwīd capture
+experience showcased across TarteelAI's public repositories. They provide a drop-in
+microphone stream handler and a speech recognition hook so a cross-platform recitation
+client can surface real-time transcripts, tajwīd analysis and responsive prompts.
+
+## Hooks
+
+### `useMicrophoneStream`
+- Wraps `react-native-microphone-stream` with declarative React state.
+- Normalises raw PCM frames into Float32 buffers ready for waveform streaming or
+  WebSocket uploads.
+- Handles app backgrounding automatically so live sessions pause when a learner
+  minimises the experience and resume when they return.
+
+### `useSpeechRecognition`
+- Wraps `@react-native-voice/voice` with status tracking, partial/final transcript
+  aggregation and volume monitoring.
+- Supports continuous sessions by automatically re-arming the recogniser once a
+  final transcript arrives, enabling uninterrupted tajwīd feedback loops.
+
+### `LiveRecitationSession`
+- Couples both hooks and exposes a render-prop so UI layers can wire up controls
+  while keeping streaming logic isolated.
+- Emits microphone chunks, partial captions and final recognised text — the same
+  signals required for the live tajwīd analyser in the web dashboard.
+
+## Usage Example
+
+```tsx
+import { LiveRecitationSession } from "@/mobile/components/LiveRecitationSession"
+
+export function MobileTajweedSession() {
+  return (
+    <LiveRecitationSession
+      autoStart
+      locale="ar-SA"
+      onAudioChunk={(chunk) => console.log("buffer", chunk.length)}
+      onPartialTranscript={(partial) => console.log("partial", partial)}
+      onFinalTranscript={(final) => console.log("final", final)}
+    >
+      {({ startSession, stopSession, microphone, speech }) => (
+        <>
+          {/* Render native UI controls here */}
+          <Button title={microphone.isActive ? "Stop" : "Start"} onPress={microphone.isActive ? stopSession : startSession} />
+          <Text>{speech.partialTranscript || speech.aggregatedTranscript}</Text>
+        </>
+      )}
+    </LiveRecitationSession>
+  )
+}
+```
+
+These utilities remain tree-shakable from the Next.js web build while giving the
+React Native client parity with Tarteel's live recitation workflow.

--- a/mobile/components/LiveRecitationSession.tsx
+++ b/mobile/components/LiveRecitationSession.tsx
@@ -1,0 +1,69 @@
+import { useCallback, useEffect } from "react"
+import type { ReactNode } from "react"
+
+import type { MicrophoneChunkListener } from "../hooks/useMicrophoneStream"
+import { useMicrophoneStream } from "../hooks/useMicrophoneStream"
+import { useSpeechRecognition } from "../hooks/useSpeechRecognition"
+
+export interface LiveRecitationSessionRenderState {
+  startSession: () => void
+  stopSession: () => void
+  microphone: ReturnType<typeof useMicrophoneStream>
+  speech: ReturnType<typeof useSpeechRecognition>
+}
+
+export interface LiveRecitationSessionProps {
+  /** Automatically start microphone capture and speech recognition. */
+  autoStart?: boolean
+  /** Locale string forwarded to the speech recogniser. */
+  locale?: string
+  /** Receives raw audio buffers (Float32) captured from the microphone. */
+  onAudioChunk?: MicrophoneChunkListener
+  /** Receives aggregated final transcripts from the recogniser. */
+  onFinalTranscript?: (transcript: string) => void
+  /** Receives partial transcripts emitted during recognition. */
+  onPartialTranscript?: (transcript: string) => void
+  /** Render prop exposing the live session state. */
+  children?: (state: LiveRecitationSessionRenderState) => ReactNode
+}
+
+export function LiveRecitationSession({
+  autoStart = false,
+  locale,
+  onAudioChunk,
+  onFinalTranscript,
+  onPartialTranscript,
+  children,
+}: LiveRecitationSessionProps) {
+  const microphone = useMicrophoneStream({ autoStart: false, onChunk: onAudioChunk })
+  const speech = useSpeechRecognition({
+    autoStart: false,
+    locale,
+    onFinalResult: onFinalTranscript,
+    onPartialResult: onPartialTranscript,
+  })
+
+  const startSession = useCallback(() => {
+    microphone.start()
+    speech.start(locale)
+  }, [locale, microphone, speech])
+
+  const stopSession = useCallback(() => {
+    microphone.stop()
+    speech.stop()
+  }, [microphone, speech])
+
+  useEffect(() => {
+    if (!autoStart) return
+    startSession()
+    return () => {
+      stopSession()
+    }
+  }, [autoStart, startSession, stopSession])
+
+  if (!children) {
+    return null
+  }
+
+  return <>{children({ startSession, stopSession, microphone, speech })}</>
+}

--- a/mobile/hooks/useMicrophoneStream.ts
+++ b/mobile/hooks/useMicrophoneStream.ts
@@ -1,0 +1,188 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { AppState, type AppStateStatus, Platform } from "react-native"
+import MicStream, {
+  type MicrophoneStreamChunk,
+  type MicrophoneStreamHandle,
+  type MicrophoneStreamInitOptions,
+} from "react-native-microphone-stream"
+
+export type MicrophoneStreamState = "idle" | "starting" | "active" | "paused" | "stopped"
+
+export type MicrophoneChunkListener = (
+  normalized: Float32Array,
+  raw: MicrophoneStreamChunk,
+) => void
+
+export interface UseMicrophoneStreamOptions extends MicrophoneStreamInitOptions {
+  /** Automatically start streaming when the hook mounts. */
+  autoStart?: boolean
+  /** Forward each captured audio chunk to the provided callback. */
+  onChunk?: MicrophoneChunkListener
+  /** Attempt to normalise PCM data into a -1 to 1 Float32Array. */
+  normalize?: boolean
+}
+
+const DEFAULT_STREAM_OPTIONS: Required<Pick<MicrophoneStreamInitOptions, "bufferSize" | "sampleRate" | "bitsPerChannel" | "channelsPerFrame">> = {
+  bufferSize: 4096,
+  sampleRate: 44100,
+  bitsPerChannel: 16,
+  channelsPerFrame: 1,
+}
+
+const isNativePlatform = Platform.OS !== "web"
+
+function normaliseChunk(chunk: MicrophoneStreamChunk, normalize: boolean): Float32Array {
+  if (!normalize) {
+    if (chunk instanceof Float32Array) return chunk
+    if (Array.isArray(chunk)) return Float32Array.from(chunk)
+    return new Float32Array(chunk)
+  }
+
+  if (chunk instanceof Float32Array) {
+    return chunk
+  }
+
+  if (Array.isArray(chunk)) {
+    return Float32Array.from(chunk.map((value) => {
+      const bounded = Math.max(-32768, Math.min(32767, value))
+      return bounded / 32768
+    }))
+  }
+
+  const view = new DataView(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+  const samples = new Float32Array(chunk.byteLength / 2)
+  for (let i = 0; i < samples.length; i++) {
+    samples[i] = view.getInt16(i * 2, true) / 32768
+  }
+  return samples
+}
+
+export function useMicrophoneStream({
+  autoStart = false,
+  onChunk,
+  normalize = true,
+  ...initOptions
+}: UseMicrophoneStreamOptions = {}) {
+  const [state, setState] = useState<MicrophoneStreamState>("idle")
+  const [error, setError] = useState<string | null>(null)
+  const listenerRef = useRef<MicrophoneStreamHandle | null>(null)
+  const shouldResumeRef = useRef(false)
+  const options = useMemo(
+    () => ({ ...DEFAULT_STREAM_OPTIONS, ...initOptions }),
+    [initOptions],
+  )
+
+  const detachListener = useCallback(() => {
+    listenerRef.current?.remove()
+    listenerRef.current = null
+  }, [])
+
+  const attachListener = useCallback(() => {
+    detachListener()
+    listenerRef.current = MicStream.addListener((chunk) => {
+      if (!onChunk) return
+      const normalized = normaliseChunk(chunk, normalize)
+      onChunk(normalized, chunk)
+    })
+  }, [detachListener, normalize, onChunk])
+
+  const stop = useCallback(() => {
+    if (!isNativePlatform) return
+    try {
+      MicStream.stop()
+      MicStream.pause()
+      MicStream.removeAllListeners?.()
+    } catch {
+      // Ignore errors triggered when stopping an already-stopped stream.
+    }
+    detachListener()
+    setState("stopped")
+  }, [detachListener])
+
+  const start = useCallback(() => {
+    if (!isNativePlatform) {
+      setError("Microphone streaming is only supported on native mobile builds.")
+      return
+    }
+    if (state === "active" || state === "starting") return
+    setState("starting")
+    setError(null)
+    try {
+      MicStream.init(options)
+      attachListener()
+      MicStream.start()
+      setState("active")
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : "Unable to start microphone stream"
+      setError(message)
+      setState("idle")
+      detachListener()
+    }
+  }, [attachListener, detachListener, options, state])
+
+  const pause = useCallback(() => {
+    if (!isNativePlatform) return
+    try {
+      MicStream.pause()
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Unable to pause microphone stream")
+    }
+    setState("paused")
+  }, [])
+
+  const resume = useCallback(() => {
+    if (!isNativePlatform) return
+    try {
+      MicStream.start()
+      setState("active")
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Unable to resume microphone stream")
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!isNativePlatform) return
+    const subscription = AppState.addEventListener("change", (next: AppStateStatus) => {
+      if (next === "active") {
+        if (shouldResumeRef.current && state === "paused") {
+          resume()
+        }
+        shouldResumeRef.current = false
+        return
+      }
+
+      if (state === "active") {
+        shouldResumeRef.current = true
+        pause()
+      }
+    })
+
+    return () => {
+      subscription.remove()
+    }
+  }, [pause, resume, state])
+
+  useEffect(() => {
+    if (!autoStart) return
+    start()
+    return () => {
+      stop()
+    }
+  }, [autoStart, start, stop])
+
+  useEffect(() => () => {
+    stop()
+  }, [stop])
+
+  return {
+    state,
+    error,
+    start,
+    stop,
+    pause,
+    resume,
+    isActive: state === "active",
+    isStarting: state === "starting",
+    isPaused: state === "paused",
+  }
+}

--- a/mobile/hooks/useSpeechRecognition.ts
+++ b/mobile/hooks/useSpeechRecognition.ts
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import Voice, {
+  type SpeechErrorEvent,
+  type SpeechPartialResultsEvent,
+  type SpeechResultsEvent,
+  type SpeechVolumeChangeEvent,
+} from "@react-native-voice/voice"
+import { Platform } from "react-native"
+
+export type SpeechRecognitionStatus = "idle" | "starting" | "listening" | "stopping" | "error"
+
+export interface UseSpeechRecognitionOptions {
+  /** Automatically begin listening when the hook mounts. */
+  autoStart?: boolean
+  /** Locale string passed to the underlying recogniser. Defaults to Modern Standard Arabic. */
+  locale?: string
+  /** Called whenever the recogniser reports a new partial transcript. */
+  onPartialResult?: (transcript: string) => void
+  /** Called when the recogniser yields a final transcript block. */
+  onFinalResult?: (transcript: string) => void
+  /** Called when a recognition error occurs. */
+  onError?: (payload: { code: string; message: string }) => void
+  /** If true, restart recognition automatically when a session ends. */
+  continuous?: boolean
+  /** Options forwarded to the underlying native recogniser. */
+  engineOptions?: Record<string, unknown>
+}
+
+const DEFAULT_LOCALE = "ar-SA"
+
+const isNativePlatform = Platform.OS !== "web"
+
+export function useSpeechRecognition({
+  autoStart = false,
+  locale = DEFAULT_LOCALE,
+  onPartialResult,
+  onFinalResult,
+  onError,
+  continuous = false,
+  engineOptions,
+}: UseSpeechRecognitionOptions = {}) {
+  const [status, setStatus] = useState<SpeechRecognitionStatus>("idle")
+  const [error, setError] = useState<string | null>(null)
+  const [partialTranscript, setPartialTranscript] = useState("")
+  const [finalTranscripts, setFinalTranscripts] = useState<string[]>([])
+  const [volume, setVolume] = useState(0)
+  const [isAvailable, setIsAvailable] = useState<boolean | null>(null)
+  const pendingRestartRef = useRef(false)
+  const mergedEngineOptions = useMemo(() => engineOptions ?? {}, [engineOptions])
+
+  const aggregatedTranscript = useMemo(
+    () => finalTranscripts.filter(Boolean).join(" ").trim(),
+    [finalTranscripts],
+  )
+
+  const reset = useCallback(() => {
+    setError(null)
+    setPartialTranscript("")
+    setFinalTranscripts([])
+    setStatus("idle")
+    setVolume(0)
+  }, [])
+
+  const assignHandlers = useCallback(() => {
+    Voice.onSpeechStart = () => {
+      setStatus("listening")
+      setError(null)
+    }
+
+    Voice.onSpeechResults = (event: SpeechResultsEvent) => {
+      const transcript = (event.value ?? []).join(" ").trim()
+      if (!transcript) return
+      setFinalTranscripts((current) => [...current, transcript])
+      setPartialTranscript("")
+      onFinalResult?.(transcript)
+      if (continuous) {
+        pendingRestartRef.current = true
+      }
+    }
+
+    Voice.onSpeechPartialResults = (event: SpeechPartialResultsEvent) => {
+      const transcript = (event.value ?? []).join(" ").trim()
+      setPartialTranscript(transcript)
+      if (transcript) {
+        onPartialResult?.(transcript)
+      }
+    }
+
+    Voice.onSpeechError = (event: SpeechErrorEvent) => {
+      const payload = event.error
+      const message = payload?.message ?? "Speech recognition failed"
+      const code = payload?.code ?? "unknown"
+      setError(message)
+      setStatus("error")
+      onError?.({ code, message })
+    }
+
+    Voice.onSpeechVolumeChanged = (event: SpeechVolumeChangeEvent) => {
+      setVolume(event.value)
+    }
+  }, [continuous, onError, onFinalResult, onPartialResult])
+
+  const clearHandlers = useCallback(() => {
+    Voice.onSpeechStart = undefined
+    Voice.onSpeechResults = undefined
+    Voice.onSpeechPartialResults = undefined
+    Voice.onSpeechError = undefined
+    Voice.onSpeechVolumeChanged = undefined
+  }, [])
+
+  const start = useCallback(
+    async (startLocale?: string, options?: Record<string, unknown>) => {
+      if (!isNativePlatform) {
+        setError("Speech recognition is only available on native mobile builds.")
+        return
+      }
+      if (status === "starting" || status === "listening") return
+      setStatus("starting")
+      setError(null)
+      try {
+        await Voice.start(startLocale ?? locale, {
+          EXTRA_PARTIAL_RESULTS: true,
+          ...mergedEngineOptions,
+          ...options,
+        })
+      } catch (caught) {
+        const message = caught instanceof Error ? caught.message : "Unable to start speech recognition"
+        setError(message)
+        setStatus("error")
+      }
+    },
+    [locale, mergedEngineOptions, status],
+  )
+
+  const stop = useCallback(async () => {
+    if (!isNativePlatform) return
+    if (status !== "listening") return
+    setStatus("stopping")
+    try {
+      await Voice.stop()
+      setStatus("idle")
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : "Unable to stop speech recognition"
+      setError(message)
+      setStatus("error")
+    }
+  }, [status])
+
+  const cancel = useCallback(async () => {
+    if (!isNativePlatform) return
+    try {
+      await Voice.cancel()
+      reset()
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Unable to cancel speech recognition")
+    }
+  }, [reset])
+
+  useEffect(() => {
+    if (!isNativePlatform) {
+      setIsAvailable(false)
+      return
+    }
+
+    assignHandlers()
+    Voice.isAvailable()
+      .then((available) => setIsAvailable(available))
+      .catch(() => setIsAvailable(null))
+
+    return () => {
+      clearHandlers()
+      Voice.destroy().catch(() => undefined)
+    }
+  }, [assignHandlers, clearHandlers])
+
+  useEffect(() => {
+    if (!continuous) return
+    if (pendingRestartRef.current && status === "idle") {
+      pendingRestartRef.current = false
+      start()
+    }
+  }, [continuous, start, status])
+
+  useEffect(() => {
+    if (!autoStart) return
+    start()
+    return () => {
+      cancel()
+    }
+  }, [autoStart, cancel, start])
+
+  return {
+    status,
+    error,
+    partialTranscript,
+    finalTranscripts,
+    aggregatedTranscript,
+    volume,
+    isListening: status === "listening",
+    isAvailable,
+    start,
+    stop,
+    cancel,
+    reset,
+  }
+}

--- a/types/react-native-microphone-stream.d.ts
+++ b/types/react-native-microphone-stream.d.ts
@@ -1,0 +1,30 @@
+declare module "react-native-microphone-stream" {
+  export type MicrophoneStreamInitOptions = {
+    bufferSize?: number
+    sampleRate?: number
+    bitsPerChannel?: number
+    channelsPerFrame?: number
+    format?: "float" | "int"
+    audioSource?: number
+  }
+
+  export type MicrophoneStreamChunk = number[] | Float32Array | Uint8Array
+
+  export type MicrophoneStreamListener = (data: MicrophoneStreamChunk) => void
+
+  export interface MicrophoneStreamHandle {
+    remove(): void
+  }
+
+  export interface MicrophoneStreamModule {
+    init(options?: MicrophoneStreamInitOptions): void
+    start(): void
+    stop(): void
+    pause(): void
+    addListener(listener: MicrophoneStreamListener): MicrophoneStreamHandle
+    removeAllListeners?(): void
+  }
+
+  const MicStream: MicrophoneStreamModule
+  export default MicStream
+}

--- a/types/react-native-voice.d.ts
+++ b/types/react-native-voice.d.ts
@@ -1,0 +1,27 @@
+declare module "@react-native-voice/voice" {
+  export type SpeechStartEvent = { error?: string | null }
+  export type SpeechEndEvent = Record<string, never>
+  export type SpeechResultsEvent = { value?: string[] }
+  export type SpeechPartialResultsEvent = { value?: string[] }
+  export type SpeechErrorEvent = { error: { message: string; code: string } }
+  export type SpeechVolumeChangeEvent = { value: number }
+
+  export type SpeechEventHandler<T> = (event: T) => void
+
+  export interface VoiceModule {
+    onSpeechStart?: SpeechEventHandler<SpeechStartEvent>
+    onSpeechEnd?: SpeechEventHandler<SpeechEndEvent>
+    onSpeechResults?: SpeechEventHandler<SpeechResultsEvent>
+    onSpeechPartialResults?: SpeechEventHandler<SpeechPartialResultsEvent>
+    onSpeechError?: SpeechEventHandler<SpeechErrorEvent>
+    onSpeechVolumeChanged?: SpeechEventHandler<SpeechVolumeChangeEvent>
+    start(locale: string, options?: Record<string, unknown>): Promise<void>
+    stop(): Promise<void>
+    cancel(): Promise<void>
+    destroy(): Promise<void>
+    isAvailable(): Promise<boolean>
+  }
+
+  const Voice: VoiceModule
+  export default Voice
+}

--- a/types/react-native.d.ts
+++ b/types/react-native.d.ts
@@ -1,0 +1,17 @@
+declare module "react-native" {
+  export type AppStateStatus = "active" | "background" | "inactive" | "unknown" | "extension"
+
+  export interface AppStateStatic {
+    currentState: AppStateStatus
+    addEventListener(type: "change", listener: (state: AppStateStatus) => void): { remove(): void }
+  }
+
+  export const AppState: AppStateStatic
+
+  export interface PlatformStatic {
+    OS: "ios" | "android" | "web" | "macos" | "windows" | "native"
+    select<T>(spec: { [platform: string]: T }): T
+  }
+
+  export const Platform: PlatformStatic
+}


### PR DESCRIPTION
## Summary
- add React Native microphone streaming hook that normalises audio chunks and manages lifecycle events
- wrap @react-native-voice/voice into a React hook with status tracking and transcript aggregation, plus a LiveRecitationSession helper
- document the mobile utilities and provide TypeScript module declarations for the React Native dependencies

## Testing
- npx eslint mobile/hooks mobile/components

------
https://chatgpt.com/codex/tasks/task_e_68e496a1af808327962291cc17c3230a