### PR TITLE
Add tajweed operations control center

### DIFF
--- a/app/tajweed-lab/page.tsx
+++ b/app/tajweed-lab/page.tsx
@@ -1,0 +1,229 @@
+"use client"
+
+import AppLayout from "@/components/app-layout"
+import { RecitationLab } from "@/components/tajweed/recitation-lab"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Separator } from "@/components/ui/separator"
+import { tajweedContentCapabilities, priorityStyles } from "@/data/qul-capabilities"
+import { datasetCurationStages } from "@/data/tarteel-dataset-plan"
+import { tajweedRoadmap } from "@/data/tajweed-roadmap"
+import { cn } from "@/lib/utils"
+import { BookOpen, ClipboardList, Compass, Database, ShieldCheck, Sparkles } from "lucide-react"
+
+const workflowPhaseCopy: Record<(typeof tajweedContentCapabilities)[number]["workflowPhase"], string> = {
+  ingest: "Capture",
+  review: "Review",
+  feedback: "Coach",
+  governance: "Govern",
+}
+
+export default function TajweedLabPage() {
+  return (
+    <AppLayout>
+      <div className="space-y-10 p-6 md:p-10">
+        <header className="flex flex-col gap-4 rounded-3xl border border-maroon-100 bg-gradient-to-br from-white via-rose-50 to-maroon-50 p-8 shadow-sm">
+          <div className="flex flex-wrap items-center gap-3">
+            <Badge className="bg-maroon-100 text-maroon-800 border-maroon-200">Tajweed Ops</Badge>
+            <Badge variant="secondary" className="gap-1">
+              <Sparkles className="h-3 w-3" /> Integrated with QUL
+            </Badge>
+          </div>
+          <h1 className="text-3xl font-semibold text-maroon-950 md:text-4xl">Correction Control Center</h1>
+          <p className="max-w-3xl text-base text-maroon-700 md:text-lg">
+            Manage live recitation capture, reviewer workflows, and Mushaf-aligned insights in a single screen. Everything below
+            maps directly to QUL services so the platform can scale from a pilot cohort to institute-wide adoption.
+          </p>
+        </header>
+
+        <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+          <Card className="border-maroon-100 bg-white/95">
+            <CardHeader>
+              <div className="flex items-center gap-3">
+                <BookOpen className="h-5 w-5 text-maroon-600" />
+                <div>
+                  <CardTitle className="text-2xl text-maroon-900">Content Ops Priorities</CardTitle>
+                  <CardDescription>
+                    Highest leverage capabilities for tajweed correction and their equivalents inside the QUL stack.
+                  </CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {tajweedContentCapabilities.map((capability) => (
+                <div
+                  key={capability.id}
+                  className="rounded-2xl border border-maroon-100 bg-gradient-to-br from-white to-rose-50 p-5"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold uppercase tracking-wide text-maroon-600">
+                        {workflowPhaseCopy[capability.workflowPhase]}
+                      </p>
+                      <h3 className="text-lg font-semibold text-maroon-900">{capability.capability}</h3>
+                    </div>
+                    <Badge className={cn("border text-xs uppercase", priorityStyles[capability.priority])}>
+                      {capability.priority}
+                    </Badge>
+                  </div>
+                  <p className="mt-3 text-sm text-maroon-700">{capability.description}</p>
+                  <div className="mt-4 flex flex-wrap items-center gap-2 text-sm text-maroon-600">
+                    <Badge variant="outline" className="border-dashed border-maroon-200 text-maroon-700">
+                      QUL · {capability.qulEquivalent}
+                    </Badge>
+                    {capability.signals.map((signal) => (
+                      <Badge key={signal} variant="secondary" className="bg-maroon-100 text-maroon-700">
+                        {signal}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card className="border-maroon-100 bg-white/95">
+            <CardHeader>
+              <div className="flex items-center gap-3">
+                <ShieldCheck className="h-5 w-5 text-maroon-600" />
+                <div>
+                  <CardTitle className="text-xl text-maroon-900">Workflow guardrails</CardTitle>
+                  <CardDescription>Governance checks to keep reviews fast, fair, and auditable.</CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4 text-sm text-maroon-700">
+              <div className="rounded-xl border border-emerald-200 bg-emerald-50/70 p-4">
+                <p className="font-semibold text-emerald-900">Real-time queue health</p>
+                <p className="mt-1 text-emerald-800">
+                  Autobalance correction load when a reviewer is at capacity using QUL&apos;s `TriagePolicy` hooks.
+                </p>
+              </div>
+              <div className="rounded-xl border border-amber-200 bg-amber-50/70 p-4">
+                <p className="font-semibold text-amber-900">Audit-ready footprints</p>
+                <p className="mt-1 text-amber-800">
+                  Every annotation is stamped with isnad level, tajweed rule code, and audio offset for compliance snapshots.
+                </p>
+              </div>
+              <div className="rounded-xl border border-maroon-200 bg-maroon-50/70 p-4">
+                <p className="font-semibold text-maroon-900">Feedback SLAs</p>
+                <p className="mt-1 text-maroon-800">
+                  Dashboards alert mentors when correction latency exceeds 24 hours so learners stay motivated.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+
+        <RecitationLab />
+
+        <section className="grid gap-6 lg:grid-cols-2">
+          <Card className="border-maroon-100 bg-white/95">
+            <CardHeader>
+              <div className="flex items-center gap-3">
+                <Database className="h-5 w-5 text-maroon-600" />
+                <div>
+                  <CardTitle className="text-2xl text-maroon-900">Dataset curation sprint</CardTitle>
+                  <CardDescription>Operational checklist for the next wave of tajweed training data.</CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {datasetCurationStages.map((stage, index) => (
+                <div key={stage.id} className="rounded-2xl border border-maroon-100 bg-maroon-50/60 p-5">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-maroon-600">Stage {index + 1}</p>
+                      <h3 className="text-lg font-semibold text-maroon-900">{stage.title}</h3>
+                    </div>
+                    <Badge variant="secondary" className="bg-maroon-100 text-maroon-700">
+                      {stage.tooling.length} tools
+                    </Badge>
+                  </div>
+                  <p className="mt-3 text-sm text-maroon-700">{stage.objective}</p>
+                  <Separator className="my-4" />
+                  <div className="grid gap-2 text-sm text-maroon-700">
+                    <p className="font-semibold text-maroon-800">Tooling</p>
+                    <div className="flex flex-wrap gap-2">
+                      {stage.tooling.map((tool) => (
+                        <Badge key={tool} variant="outline" className="border-dashed border-maroon-200 text-maroon-700">
+                          {tool}
+                        </Badge>
+                      ))}
+                    </div>
+                    <p className="mt-3 font-semibold text-maroon-800">Outputs</p>
+                    <ul className="list-inside list-disc space-y-1">
+                      {stage.outputs.map((output) => (
+                        <li key={output}>{output}</li>
+                      ))}
+                    </ul>
+                    <p className="mt-3 text-sm font-medium text-maroon-800">QA gate</p>
+                    <p className="text-sm text-maroon-700">{stage.qa}</p>
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card className="border-maroon-100 bg-white/95">
+            <CardHeader>
+              <div className="flex items-center gap-3">
+                <Compass className="h-5 w-5 text-maroon-600" />
+                <div>
+                  <CardTitle className="text-2xl text-maroon-900">Typography & review roadmap</CardTitle>
+                  <CardDescription>Sequence to unlock Mushaf-perfect rendering with permissioned QA.</CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {tajweedRoadmap.map((milestone, index) => (
+                <div key={milestone.id} className="rounded-2xl border border-maroon-100 bg-rose-50/60 p-5">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wide text-maroon-600">
+                        Milestone {index + 1}
+                      </p>
+                      <h3 className="text-lg font-semibold text-maroon-900">{milestone.title}</h3>
+                    </div>
+                    <Badge variant="secondary" className="bg-maroon-100 text-maroon-700">
+                      {milestone.target}
+                    </Badge>
+                  </div>
+                  <p className="mt-3 text-sm text-maroon-700">{milestone.focus}</p>
+                  <div className="mt-4 space-y-2 text-sm text-maroon-700">
+                    <div>
+                      <p className="font-semibold text-maroon-800">Dependencies</p>
+                      <ul className="list-inside list-disc space-y-1">
+                        {milestone.dependencies.map((dependency) => (
+                          <li key={dependency}>{dependency}</li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div>
+                      <p className="font-semibold text-maroon-800">Definition of success</p>
+                      <p>{milestone.success}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </section>
+
+        <footer className="rounded-3xl border border-maroon-100 bg-maroon-900 p-8 text-maroon-100">
+          <div className="flex flex-wrap items-center gap-4">
+            <ClipboardList className="h-6 w-6" />
+            <div>
+              <h2 className="text-lg font-semibold">Next action</h2>
+              <p className="text-sm text-maroon-100/90">
+                Ship the recitation lab to a pilot classroom, capture transcripts for 10 sessions, and dry-run the review queue
+                with mentors before inviting beta testers.
+              </p>
+            </div>
+          </div>
+        </footer>
+      </div>
+    </AppLayout>
+  )
+}
+

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -36,6 +36,7 @@ export default function Navigation() {
     { name: "Play Games", href: "/games", icon: Gamepad2 },
     { name: "Habit Quest", href: "/habits", icon: Gamepad2 },
     { name: "Qur'an Reader", href: "/reader", icon: BookOpen },
+    { name: "Tajweed Lab", href: "/tajweed-lab", icon: Sparkles },
     { name: "Memorization", href: "/student/memorization", icon: Target },
     { name: "Progress", href: "/progress", icon: BarChart3 },
     { name: "Achievements", href: "/achievements", icon: Trophy },

--- a/components/tajweed/recitation-lab.tsx
+++ b/components/tajweed/recitation-lab.tsx
@@ -1,0 +1,415 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Separator } from "@/components/ui/separator"
+import { Textarea } from "@/components/ui/textarea"
+import { cn } from "@/lib/utils"
+import { AlertCircle, CheckCircle2, Mic, Pause, Play, Waves } from "lucide-react"
+
+interface TranscriptLog {
+  id: string
+  transcript: string
+  confidence?: number
+  timestamp: string
+}
+
+type PermissionState = "idle" | "granted" | "denied"
+
+type SpeechRecognitionAlternativeLike = {
+  transcript: string
+  confidence: number
+}
+
+type SpeechRecognitionResultLike = {
+  isFinal: boolean
+  0: SpeechRecognitionAlternativeLike
+  length: number
+}
+
+type SpeechRecognitionEventLike = {
+  results: {
+    length: number
+    item: (index: number) => SpeechRecognitionResultLike
+    [index: number]: SpeechRecognitionResultLike
+  }
+}
+
+type SpeechRecognitionLike = {
+  lang: string
+  continuous: boolean
+  interimResults: boolean
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null
+  onerror: ((event: { error: string; message?: string }) => void) | null
+  start: () => void
+  stop: () => void
+  abort: () => void
+}
+
+type SpeechRecognitionConstructor = new () => SpeechRecognitionLike
+
+const getSpeechRecognition = (): SpeechRecognitionConstructor | null => {
+  if (typeof window === "undefined") return null
+  const SpeechRecognitionImpl =
+    (window as unknown as { SpeechRecognition?: SpeechRecognitionConstructor }).SpeechRecognition ??
+    (window as unknown as { webkitSpeechRecognition?: SpeechRecognitionConstructor }).webkitSpeechRecognition
+  return SpeechRecognitionImpl ?? null
+}
+
+const formatElapsed = (milliseconds: number) => {
+  if (milliseconds <= 0) return "0:00"
+  const totalSeconds = Math.floor(milliseconds / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`
+}
+
+export function RecitationLab() {
+  const [permissionState, setPermissionState] = useState<PermissionState>("idle")
+  const [isRecording, setIsRecording] = useState(false)
+  const [isSpeechSupported, setIsSpeechSupported] = useState(false)
+  const [transcripts, setTranscripts] = useState<TranscriptLog[]>([])
+  const [sessionNotes, setSessionNotes] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [sessionDuration, setSessionDuration] = useState(0)
+  const [streamSize, setStreamSize] = useState(0)
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null)
+  const audioStreamRef = useRef<MediaStream | null>(null)
+  const recognitionRef = useRef<SpeechRecognitionLike | null>(null)
+  const startTimeRef = useRef<number | null>(null)
+  const sessionChunksRef = useRef<Blob[]>([])
+  const rafRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    const recognizer = getSpeechRecognition()
+    setIsSpeechSupported(Boolean(recognizer))
+  }, [])
+
+  useEffect(() => {
+    if (!isRecording) {
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = null
+      }
+      return
+    }
+
+    const tick = () => {
+      if (startTimeRef.current) {
+        setSessionDuration(Date.now() - startTimeRef.current)
+      }
+      rafRef.current = requestAnimationFrame(tick)
+    }
+
+    rafRef.current = requestAnimationFrame(tick)
+
+    return () => {
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = null
+      }
+    }
+  }, [isRecording])
+
+  const resetSession = useCallback(() => {
+    mediaRecorderRef.current?.stop()
+    recognitionRef.current?.stop()
+    audioStreamRef.current?.getTracks().forEach((track) => track.stop())
+    mediaRecorderRef.current = null
+    recognitionRef.current = null
+    audioStreamRef.current = null
+    startTimeRef.current = null
+    sessionChunksRef.current = []
+    setIsRecording(false)
+    setSessionDuration(0)
+    setStreamSize(0)
+  }, [])
+
+  const handlePermission = useCallback(async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      setPermissionState("granted")
+      audioStreamRef.current = stream
+      return stream
+    } catch (err) {
+      console.error("Failed to access microphone", err)
+      setPermissionState("denied")
+      setError("Microphone permission denied. Enable audio access to begin streaming.")
+      throw err
+    }
+  }, [])
+
+  const setupSpeechRecognition = useCallback(() => {
+    const SpeechRecognitionImpl = getSpeechRecognition()
+    if (!SpeechRecognitionImpl) {
+      return null
+    }
+
+    const recognition = new SpeechRecognitionImpl()
+    recognition.lang = "ar-SA"
+    recognition.continuous = true
+    recognition.interimResults = true
+    recognition.onerror = (event) => {
+      console.warn("Speech recognition error", event)
+      setError(`Speech recognition error: ${event.error}`)
+    }
+    recognition.onresult = (event) => {
+      for (let i = event.results.length - 1; i >= 0; i -= 1) {
+        const result = event.results[i]
+        if (!result.isFinal) continue
+        const alternative = result[0]
+        if (!alternative) continue
+        setTranscripts((prev) => [
+          {
+            id: crypto.randomUUID(),
+            transcript: alternative.transcript.trim(),
+            confidence: alternative.confidence,
+            timestamp: new Date().toISOString(),
+          },
+          ...prev,
+        ])
+        break
+      }
+    }
+    return recognition
+  }, [])
+
+  const startRecording = useCallback(async () => {
+    setError(null)
+    try {
+      const stream = audioStreamRef.current ?? (await handlePermission())
+      if (!stream) {
+        throw new Error("Microphone stream not available")
+      }
+
+      const recorder = new MediaRecorder(stream, { mimeType: "audio/webm" })
+      sessionChunksRef.current = []
+      recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          sessionChunksRef.current.push(event.data)
+          setStreamSize((size) => size + event.data.size)
+        }
+      }
+      recorder.start(1000)
+      mediaRecorderRef.current = recorder
+
+      const recognition = setupSpeechRecognition()
+      if (recognition) {
+        recognitionRef.current = recognition
+        recognition.start()
+      }
+
+      startTimeRef.current = Date.now()
+      setIsRecording(true)
+      setSessionDuration(0)
+    } catch (err) {
+      console.error("Unable to start recording", err)
+      setError("Unable to start recording. Check microphone availability and try again.")
+      resetSession()
+    }
+  }, [handlePermission, resetSession, setupSpeechRecognition])
+
+  const stopRecording = useCallback(() => {
+    mediaRecorderRef.current?.stop()
+    recognitionRef.current?.stop()
+    audioStreamRef.current?.getTracks().forEach((track) => track.stop())
+    mediaRecorderRef.current = null
+    recognitionRef.current = null
+    audioStreamRef.current = null
+    startTimeRef.current = null
+    setIsRecording(false)
+  }, [])
+
+  const exportSession = useCallback(() => {
+    if (sessionChunksRef.current.length === 0 && transcripts.length === 0) {
+      setError("Nothing to export yet. Record audio or capture a transcript first.")
+      return
+    }
+
+    const payload = {
+      startedAt: transcripts[0]?.timestamp ?? new Date().toISOString(),
+      durationMs: sessionDuration,
+      notes: sessionNotes,
+      transcripts,
+    }
+
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" })
+    const blobUrl = URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = blobUrl
+    link.download = `tajweed-session-${Date.now()}.json`
+    link.click()
+    URL.revokeObjectURL(blobUrl)
+  }, [sessionDuration, sessionNotes, transcripts])
+
+  const downloadAudio = useCallback(() => {
+    if (sessionChunksRef.current.length === 0) {
+      setError("Record some audio before downloading the session clip.")
+      return
+    }
+    const audioBlob = new Blob(sessionChunksRef.current, { type: "audio/webm" })
+    const blobUrl = URL.createObjectURL(audioBlob)
+    const link = document.createElement("a")
+    link.href = blobUrl
+    link.download = `tajweed-session-${Date.now()}.webm`
+    link.click()
+    URL.revokeObjectURL(blobUrl)
+  }, [])
+
+  const statusBadge = useMemo(() => {
+    if (isRecording) {
+      return <Badge className="bg-red-100 text-red-700 border-red-200">Live</Badge>
+    }
+    if (permissionState === "denied") {
+      return <Badge variant="outline" className="border-red-200 text-red-700">Permission blocked</Badge>
+    }
+    if (transcripts.length > 0) {
+      return <Badge className="bg-emerald-100 text-emerald-700 border-emerald-200">Session captured</Badge>
+    }
+    return <Badge variant="secondary">Idle</Badge>
+  }, [isRecording, permissionState, transcripts.length])
+
+  const averageConfidence = useMemo(() => {
+    if (transcripts.length === 0) return null
+    const total = transcripts.reduce((sum, entry) => sum + (entry.confidence ?? 0), 0)
+    return Math.round((total / transcripts.length) * 100)
+  }, [transcripts])
+
+  return (
+    <Card className="border-maroon-100 bg-white/90 backdrop-blur">
+      <CardHeader className="flex flex-row items-start justify-between gap-4">
+        <div>
+          <CardTitle className="text-2xl font-semibold text-maroon-900">Recitation Stream</CardTitle>
+          <CardDescription>
+            Stream microphone audio, capture live transcripts, and log tajweed mistakes for offline review.
+          </CardDescription>
+        </div>
+        {statusBadge}
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid gap-6 lg:grid-cols-[3fr_2fr]">
+          <div className="space-y-4">
+            <div className="flex items-center justify-between rounded-xl border border-maroon-100 bg-maroon-50/60 p-4">
+              <div className="flex items-center gap-3">
+                <div className={cn("flex h-12 w-12 items-center justify-center rounded-full border", isRecording ? "border-red-300 bg-red-50" : "border-maroon-200 bg-white") }>
+                  {isRecording ? <Waves className="h-6 w-6 text-red-500" /> : <Mic className="h-6 w-6 text-maroon-500" />}
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-maroon-900">Session duration</p>
+                  <p className="text-2xl font-semibold text-maroon-700">{formatElapsed(sessionDuration)}</p>
+                </div>
+              </div>
+              <div className="text-right">
+                <p className="text-xs uppercase tracking-wide text-maroon-600">Captured data</p>
+                <p className="font-semibold text-maroon-800">{(streamSize / 1024).toFixed(1)} KB</p>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <Button
+                size="lg"
+                className="gap-2"
+                onClick={isRecording ? stopRecording : startRecording}
+              >
+                {isRecording ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+                {isRecording ? "Stop" : "Start"} capture
+              </Button>
+              <Button variant="outline" onClick={downloadAudio} className="gap-2">
+                <Waves className="h-4 w-4" /> Download audio
+              </Button>
+              <Button variant="secondary" onClick={exportSession} className="gap-2">
+                <CheckCircle2 className="h-4 w-4" /> Export transcript
+              </Button>
+              <Button variant="ghost" onClick={resetSession} className="gap-2 text-maroon-600">
+                Reset session
+              </Button>
+            </div>
+
+            {!isSpeechSupported && (
+              <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700">
+                <AlertCircle className="h-4 w-4" />
+                Browser speech recognition API is unavailable. Audio still records for server-side transcription.
+              </div>
+            )}
+
+            {error && (
+              <div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                <AlertCircle className="h-4 w-4" />
+                {error}
+              </div>
+            )}
+
+            <div className="space-y-3">
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-maroon-700">Session notes</h3>
+              <Textarea
+                value={sessionNotes}
+                onChange={(event) => setSessionNotes(event.target.value)}
+                placeholder="Log observed tajweed slips, reviewer assignments, or contextual notes for offline QA."
+                className="min-h-[120px] resize-y"
+              />
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-maroon-100 bg-white/80 p-4 shadow-sm">
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold text-maroon-900">Live quality signals</h3>
+              {averageConfidence !== null ? (
+                <Badge className="bg-emerald-100 text-emerald-700 border-emerald-200">{averageConfidence}% confidence</Badge>
+              ) : (
+                <Badge variant="outline">Awaiting transcript</Badge>
+              )}
+            </div>
+            <p className="mt-2 text-sm text-maroon-600">
+              Each transcript snippet is stored with a timestamp so the correction workflow can replay audio against the Mushaf
+              view.
+            </p>
+            <Separator className="my-4" />
+            <ScrollArea className="h-60 pr-2">
+              <div className="space-y-3">
+                {transcripts.length === 0 ? (
+                  <div className="rounded-lg border border-dashed border-maroon-200 p-4 text-center text-sm text-maroon-500">
+                    Start a session to populate transcripts for later tajweed error mining.
+                  </div>
+                ) : (
+                  transcripts.map((entry) => (
+                    <div key={entry.id} className="rounded-lg border border-maroon-100 bg-maroon-50/60 p-3">
+                      <p className="text-sm font-medium text-maroon-900">{entry.transcript}</p>
+                      <div className="mt-2 flex items-center justify-between text-xs text-maroon-600">
+                        <span>{new Date(entry.timestamp).toLocaleTimeString()}</span>
+                        {typeof entry.confidence === "number" && (
+                          <span>{Math.round(entry.confidence * 100)}% confidence</span>
+                        )}
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </ScrollArea>
+          </div>
+        </div>
+      </CardContent>
+      <CardFooter className="flex flex-col gap-4 border-t border-maroon-100 bg-maroon-50/50 p-6">
+        <div className="flex w-full flex-wrap items-center justify-between gap-4">
+          <div>
+            <p className="text-sm font-semibold text-maroon-900">Correction workflow readiness</p>
+            <p className="text-xs text-maroon-600">
+              Keep the browser tab active while recording to maintain a stable audio stream for tajweed scoring.
+            </p>
+          </div>
+          <div className="flex min-w-[220px] flex-col gap-2">
+            <Progress value={Math.min(100, transcripts.length * 12)} className="h-2" />
+            <p className="text-xs text-right text-maroon-600">
+              {transcripts.length} transcript{transcripts.length === 1 ? "" : "s"} captured
+            </p>
+          </div>
+        </div>
+      </CardFooter>
+    </Card>
+  )
+}
+

--- a/data/qul-capabilities.ts
+++ b/data/qul-capabilities.ts
@@ -1,0 +1,71 @@
+export type TajweedCapabilityPriority = "critical" | "high" | "medium"
+
+type ContentCapability = {
+  id: string
+  capability: string
+  description: string
+  workflowPhase: "ingest" | "review" | "feedback" | "governance"
+  qulEquivalent: string
+  priority: TajweedCapabilityPriority
+  signals: string[]
+}
+
+export const tajweedContentCapabilities: ContentCapability[] = [
+  {
+    id: "capture",
+    capability: "Live Recitation Capture",
+    description:
+      "Stream mic audio with tajweed tagging, enforce assignment metadata, and push frames to the correction queue without blocking the student.",
+    workflowPhase: "ingest",
+    qulEquivalent: "Streams > CaptureSession.create",
+    priority: "critical",
+    signals: ["student-id", "assignment-id", "tajweed-focus", "audio-chunk"],
+  },
+  {
+    id: "triage",
+    capability: "Automated Tajweed Triage",
+    description:
+      "Run frame-level heuristics and ML scoring to route mistakes to the right reviewer lane (peer, mentor, or lead sheikh).",
+    workflowPhase: "review",
+    qulEquivalent: "Pipelines > TriagePolicy",
+    priority: "high",
+    signals: ["tajweed-score", "confidence", "rule-violation", "queue-target"],
+  },
+  {
+    id: "annotation",
+    capability: "Structured Annotation Workbench",
+    description:
+      "Annotate tajweed violations alongside Mushaf-accurate verse previews, audio scrubbing, and inline commentary.",
+    workflowPhase: "review",
+    qulEquivalent: "Workspace > AnnotationCanvas",
+    priority: "high",
+    signals: ["ayah-anchor", "mushaf-position", "annotation", "severity"],
+  },
+  {
+    id: "feedback",
+    capability: "Personalized Feedback Composer",
+    description:
+      "Auto-suggest corrections mapped to learner goals and push actionable tasks back into the student's dashboard.",
+    workflowPhase: "feedback",
+    qulEquivalent: "Outbox > FeedbackTemplate",
+    priority: "medium",
+    signals: ["goal-alignment", "mistake-context", "recommended-practice"],
+  },
+  {
+    id: "insights",
+    capability: "Progress Intelligence",
+    description:
+      "Aggregate tajweed mistakes, completion rates, and reviewer latency so program leads can spot bottlenecks.",
+    workflowPhase: "governance",
+    qulEquivalent: "Dashboards > InsightDeck",
+    priority: "medium",
+    signals: ["error-density", "time-to-feedback", "rule-trends"],
+  },
+]
+
+export const priorityStyles: Record<TajweedCapabilityPriority, string> = {
+  critical: "bg-red-100 text-red-700 border-red-200",
+  high: "bg-amber-100 text-amber-700 border-amber-200",
+  medium: "bg-slate-100 text-slate-700 border-slate-200",
+}
+

--- a/data/tajweed-roadmap.ts
+++ b/data/tajweed-roadmap.ts
@@ -1,0 +1,36 @@
+export type RoadmapMilestone = {
+  id: string
+  title: string
+  focus: string
+  target: string
+  dependencies: string[]
+  success: string
+}
+
+export const tajweedRoadmap: RoadmapMilestone[] = [
+  {
+    id: "mushaf-kit",
+    title: "Mushaf typography kit",
+    focus: "Build a reusable Mushaf rendering engine that keeps glyph positions stable across browsers.",
+    target: "Design system sprint",
+    dependencies: ["svg text shaping", "uthmani font licensing"],
+    success: "Dynamic ayah overlays match Medina Mushaf pagination in QA scripts.",
+  },
+  {
+    id: "review-permissions",
+    title: "Reviewer permission flows",
+    focus: "Gate annotation tools by isnad level so senior sheikhs approve escalations while mentors handle daily corrections.",
+    target: "Platform sprint",
+    dependencies: ["role-based access control", "queue assignment service"],
+    success: "Audit log shows reviewer + verdict + tajweed score change for every session.",
+  },
+  {
+    id: "beta-readiness",
+    title: "Beta tester enablement",
+    focus: "Ship self-serve onboarding with guided quests, telemetry dashboards, and privacy gating before the wider cohort joins.",
+    target: "Adoption sprint",
+    dependencies: ["recitation lab telemetry", "feedback composer"],
+    success: "Invite-only beta sees >70% weekly active reciters with <24h feedback latency.",
+  },
+]
+

--- a/data/tarteel-dataset-plan.ts
+++ b/data/tarteel-dataset-plan.ts
@@ -1,0 +1,48 @@
+export type DatasetStage = {
+  id: string
+  title: string
+  objective: string
+  tooling: string[]
+  outputs: string[]
+  qa: string
+}
+
+export const datasetCurationStages: DatasetStage[] = [
+  {
+    id: "bootstrap",
+    title: "Bootstrap archival audio",
+    objective:
+      "Ingest instructor-approved recordings and historic halaqa sessions, then normalize gain levels and clip to ayah boundaries.",
+    tooling: ["tarteel-ml/preprocess/audio_split", "tkseem", "tnkeeh"],
+    outputs: ["ayah-aligned WAV", "session-metadata.json"],
+    qa: "Spot check 5% of clips for clipping artefacts and verify ayah hashes against Mushaf references.",
+  },
+  {
+    id: "label",
+    title: "Label tajweed violations",
+    objective:
+      "Tag mispronunciations, elongations, and qalqalah slips with rule codes so the model learns error classes, not just transcripts.",
+    tooling: ["tarteel-ml/annotate", "internal tajweed rubric"],
+    outputs: ["violation_labels.parquet", "reviewer-notes.md"],
+    qa: "Require dual review; disagreements over 0.2 confidence trigger arbitration.",
+  },
+  {
+    id: "synthesize",
+    title: "Synthesize hard negatives",
+    objective:
+      "Augment data with rule-specific perturbations (e.g., ghunnah removal) to balance sparse classes before training.",
+    tooling: ["tarteel-ml/augment", "custom formant filters"],
+    outputs: ["augmented_clips", "rule_mispronunciation_catalog"],
+    qa: "Validate augmented clips with automatic tajweed score deltas > 25% before inclusion.",
+  },
+  {
+    id: "package",
+    title: "Package training shards",
+    objective:
+      "Chunk curated audio+text into sharded TFRecords with aligned tajweed metadata for downstream Whisper fine-tuning.",
+    tooling: ["tarteel-ml/package", "manifest integrity checks"],
+    outputs: ["train-*.tfrecord", "manifest.json"],
+    qa: "SHA256 each shard and store manifests in object storage with versioned dataset IDs.",
+  },
+]
+


### PR DESCRIPTION
## Summary
- add a dedicated Tajweed Lab route that maps correction workflows to QUL content operations capabilities
- implement a RecitationLab component that streams microphone audio, hooks into browser speech recognition, and captures transcript notes for offline analysis
- document dataset curation stages and roadmap milestones for Mushaf typography and permissioned reviews, surfacing them inside the new page

## Testing
- `npm run lint` *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a1f87ef0832792e8c0e9b324e392