### PR TITLE
Add student welcome audio experience

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -20,6 +20,7 @@ import { PremiumGate } from "@/components/premium-gate"
 import { QuranFlipBook } from "@/components/quran-flipbook"
 import { LiveTajweedAnalyzer } from "@/components/live-tajweed-analyzer"
 import { useUser } from "@/hooks/use-user"
+import { StudentWelcomeAudio } from "@/components/student/StudentWelcomeAudio"
 import { getDailySurahRecommendations } from "@/lib/daily-surah"
 import {
   BookOpen,
@@ -472,18 +473,19 @@ export default function DashboardPage() {
   return (
     <>
       <AppLayout>
-      <div className="p-6">
-        {/* Welcome Section */}
-        <div className="mb-8">
-          <h2 className="text-3xl font-bold text-maroon-900 mb-2">Assalamu Alaikum, {firstName}</h2>
-          <p className="text-lg text-maroon-700">Continue your journey of Qur’anic excellence</p>
-          <div className="flex items-center mt-4">
-            <Badge className="bg-gradient-to-r from-yellow-500 to-yellow-600 text-white border-0 px-3 py-1">
-              <Star className="w-3 h-3 mr-1" />
-              {stats.hasanat.toLocaleString()} Hasanat Points
-            </Badge>
+        <div className="p-6">
+          <StudentWelcomeAudio className="mb-6" />
+          {/* Welcome Section */}
+          <div className="mb-8">
+            <h2 className="text-3xl font-bold text-maroon-900 mb-2">Assalamu Alaikum, {firstName}</h2>
+            <p className="text-lg text-maroon-700">Continue your journey of Qur’anic excellence</p>
+            <div className="flex items-center mt-4">
+              <Badge className="bg-gradient-to-r from-yellow-500 to-yellow-600 text-white border-0 px-3 py-1">
+                <Star className="w-3 h-3 mr-1" />
+                {stats.hasanat.toLocaleString()} Hasanat Points
+              </Badge>
+            </div>
           </div>
-        </div>
 
         {error && (
           <Alert className="mb-8 border-amber-200 bg-amber-50 text-amber-800">
@@ -1620,7 +1622,7 @@ export default function DashboardPage() {
             </Card>
           </div>
         </div>
-      </div>
+        </div>
       </AppLayout>
 
       {gamePanel && (

--- a/components/student/StudentWelcomeAudio.tsx
+++ b/components/student/StudentWelcomeAudio.tsx
@@ -1,0 +1,193 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { Volume2, Square, AlertTriangle } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import { useUser } from "@/hooks/use-user"
+
+const WELCOME_AUDIO_SRC = "/audio/welcome-student.mp3"
+const PLAYBACK_STORAGE_KEY = "alfawz:studentWelcome:v1"
+
+type PlaybackState = "idle" | "playing" | "ready" | "error"
+
+interface StudentWelcomeAudioProps {
+  className?: string
+}
+
+export function StudentWelcomeAudio({ className }: StudentWelcomeAudioProps) {
+  const { profile, isLoading } = useUser()
+  const audioRef = useRef<HTMLAudioElement | null>(null)
+  const [hasHeardMessage, setHasHeardMessage] = useState(false)
+  const [playbackState, setPlaybackState] = useState<PlaybackState>("idle")
+  const [hasAttemptedAutoplay, setHasAttemptedAutoplay] = useState(false)
+  const [showAutoplayNotice, setShowAutoplayNotice] = useState(false)
+
+  const isStudent = profile.role === "student"
+
+  const ensureAudio = useCallback(() => {
+    if (typeof window === "undefined") {
+      return null
+    }
+
+    if (!audioRef.current) {
+      const audio = new Audio(WELCOME_AUDIO_SRC)
+      audio.preload = "auto"
+      audio.onended = () => {
+        setPlaybackState("ready")
+      }
+      audioRef.current = audio
+    }
+
+    return audioRef.current
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    if (sessionStorage.getItem(PLAYBACK_STORAGE_KEY) === "true") {
+      setHasHeardMessage(true)
+      setPlaybackState("ready")
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    if (isLoading) {
+      return
+    }
+
+    if (!isStudent) {
+      return
+    }
+
+    if (hasAttemptedAutoplay) {
+      return
+    }
+
+    setHasAttemptedAutoplay(true)
+
+    if (sessionStorage.getItem(PLAYBACK_STORAGE_KEY) === "true") {
+      setHasHeardMessage(true)
+      setPlaybackState("ready")
+      return
+    }
+
+    const audio = ensureAudio()
+    if (!audio) {
+      return
+    }
+
+    audio.currentTime = 0
+    setPlaybackState("playing")
+
+    audio
+      .play()
+      .then(() => {
+        sessionStorage.setItem(PLAYBACK_STORAGE_KEY, "true")
+        setHasHeardMessage(true)
+        setShowAutoplayNotice(false)
+      })
+      .catch(() => {
+        setPlaybackState("error")
+        setShowAutoplayNotice(true)
+      })
+  }, [ensureAudio, hasAttemptedAutoplay, isLoading, isStudent])
+
+  useEffect(() => {
+    return () => {
+      const audio = audioRef.current
+      if (!audio) {
+        return
+      }
+      audio.pause()
+      audio.src = ""
+      audioRef.current = null
+    }
+  }, [])
+
+  const handlePlay = useCallback(async () => {
+    const audio = ensureAudio()
+    if (!audio) {
+      return
+    }
+
+    audio.currentTime = 0
+    setPlaybackState("playing")
+    try {
+      await audio.play()
+      sessionStorage.setItem(PLAYBACK_STORAGE_KEY, "true")
+      setHasHeardMessage(true)
+      setShowAutoplayNotice(false)
+    } catch {
+      setPlaybackState("error")
+      setShowAutoplayNotice(true)
+    }
+  }, [ensureAudio])
+
+  const handleStop = useCallback(() => {
+    const audio = audioRef.current
+    if (!audio) {
+      return
+    }
+    audio.pause()
+    audio.currentTime = 0
+    setPlaybackState("ready")
+  }, [])
+
+  const isStopDisabled = !audioRef.current || audioRef.current.paused
+
+  if (!isStudent) {
+    return null
+  }
+
+  return (
+    <div className={cn("rounded-2xl border border-maroon-100 bg-maroon-50 p-5 shadow-sm", className)}>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-lg font-semibold text-maroon-900">Your motivational welcome</p>
+          <p className="text-sm text-maroon-700">
+            {showAutoplayNotice
+              ? "Press play to hear your welcome message. Your browser blocked automatic playback."
+              : hasHeardMessage
+              ? "Need a boost? Replay the welcome message anytime."
+              : "We prepared a powerful welcome message to spark your study session."}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handlePlay}
+            disabled={playbackState === "playing"}
+            className="min-w-[11rem] border-maroon-200 text-maroon-900 hover:bg-maroon-100"
+          >
+            <Volume2 className="mr-2 h-4 w-4" />
+            {playbackState === "playing" ? "Playing..." : hasHeardMessage ? "Replay welcome" : "Play welcome"}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={handleStop}
+            disabled={isStopDisabled}
+            className="text-maroon-800 hover:bg-maroon-100"
+          >
+            <Square className="mr-2 h-4 w-4" />Stop
+          </Button>
+        </div>
+      </div>
+      {playbackState === "error" && (
+        <div className="mt-3 flex items-center gap-2 text-sm text-maroon-800">
+          <AlertTriangle className="h-4 w-4" />
+          Playback was blocked. Press “Play welcome” to listen.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/script.txt
+++ b/script.txt
@@ -1,0 +1,23 @@
+Upload path for the recorded audio: public/audio/welcome-student.mp3
+
+---
+Title: Dawn of Your Mastery
+
+[Soft, inspiring intro]
+Assalamu alaikum, brilliant seeker of the Qur'an.
+Take a breath and feel this moment—the moment you chose to return, to grow, to lead your soul toward light.
+
+[Build energy]
+You carry the legacy of generations who opened these same pages and found guidance, strength, and peace. Their devotion flows in your veins. Their courage whispers through every verse you recite.
+
+[Powerful call to action]
+Today, you are not merely logging in. You are stepping into your purpose. With every ayah you study, you polish your heart, you strengthen your mind, and you lift the world around you.
+
+[Emotional crescendo]
+Remember: Allah created you capable. He placed in you the discipline to stay, the resilience to rise, and the brilliance to master His words. Feel that certainty. Own that power.
+
+[Closing surge]
+So stay with us. Lean into your studies. Let every recitation ignite your spirit. Your consistency is your victory, your devotion is your crown, and your voice is the melody of this ummah’s future.
+
+[Resolute finish]
+We are honored you are here. Now, Bismillah—let’s make this session unforgettable.


### PR DESCRIPTION
## Summary
- add a dedicated `StudentWelcomeAudio` client component that auto-plays a motivational welcome message for student sessions and offers manual playback controls
- surface the new component near the top of the student dashboard and document the upload location for the accompanying audio asset
- provide a polished welcome voice-over script in `script.txt` and scaffold a public audio directory for the MP3

## Testing
- npx eslint components/student/StudentWelcomeAudio.tsx app/dashboard/page.tsx
- npm run lint *(fails: existing repository-wide lint issues unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a9cf5b6c8327b1f39991af51b0a1