### PR TITLE
Add interactive Tafsir Trivia quest experience

### DIFF
--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -2,12 +2,24 @@
 
 import Link from "next/link"
 import { useMemo } from "react"
-import { Sparkles, Zap, Shield, Target, Gamepad2, Trophy, Users, Medal, Crown } from "lucide-react"
+import {
+  BookOpenCheck,
+  Lightbulb,
+  Sparkles,
+  Zap,
+  Shield,
+  Target,
+  Gamepad2,
+  Trophy,
+  Users,
+  Medal,
+  Crown,
+} from "lucide-react"
 
 import AppLayout from "@/components/app-layout"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { Separator } from "@/components/ui/separator"
 import { useUser } from "@/hooks/use-user"
@@ -80,6 +92,81 @@ export default function GamesHubPage() {
             Season {gamePanel?.season.level ?? 1}
           </Badge>
         </header>
+
+        <section className="grid gap-4 lg:grid-cols-[3fr,2fr]">
+          <Card className="border-0 bg-gradient-to-br from-maroon-700 via-maroon-600 to-emerald-600 text-white shadow-xl">
+            <CardHeader className="space-y-3">
+              <Badge className="w-fit bg-white/15 text-white border-white/30">New Seasonal Drop</Badge>
+              <CardTitle className="text-2xl font-semibold flex items-center gap-2">
+                <BookOpenCheck className="h-5 w-5" /> Tafsir Trivia Quest
+              </CardTitle>
+              <CardDescription className="text-white/80">
+                Sprint through foundations, context, and real-world application with a fully interactive tafsir trivia game.
+                Stack streak multipliers, unlock scholar insights, and record reflections as you master each ayah.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-3 md:grid-cols-2">
+              <div className="space-y-2 text-sm text-white/90">
+                <p className="font-semibold uppercase tracking-wide text-white/70">Power-ups</p>
+                <ul className="space-y-1">
+                  <li>• Tafsir gem lifeline with scholar quotes.</li>
+                  <li>• Reflection pause for bonus hasanat streaks.</li>
+                  <li>• Option filter that clears tricky distractors.</li>
+                </ul>
+              </div>
+              <div className="space-y-2 text-sm text-white/90">
+                <p className="font-semibold uppercase tracking-wide text-white/70">Earned rewards</p>
+                <ul className="space-y-1">
+                  <li>• Knowledge score &amp; combo multipliers.</li>
+                  <li>• Guided journal log for every verse.</li>
+                  <li>• Habit quest recommendations post-game.</li>
+                </ul>
+              </div>
+            </CardContent>
+            <CardFooter className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-white/80">
+                Crafted for tafsir nights, halaqah warm-ups, and competitive family study sessions.
+              </p>
+              <Button
+                asChild
+                className="bg-white text-maroon-700 hover:bg-emerald-100 border-0 font-semibold"
+              >
+                <Link href="/games/tafsir-trivia">Launch Tafsir Trivia</Link>
+              </Button>
+            </CardFooter>
+          </Card>
+          <Card className="border-maroon-100 shadow-lg">
+            <CardHeader className="space-y-2">
+              <CardTitle className="flex items-center gap-2 text-maroon-900">
+                <Lightbulb className="h-5 w-5 text-amber-500" /> Design brainstorm
+              </CardTitle>
+              <CardDescription className="text-gray-600">
+                Highlighting the learning science powering the new tafsir mini-game.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-gray-700">
+              <div className="rounded-lg border border-maroon-100 bg-maroon-50/60 p-3">
+                <p className="font-semibold text-maroon-800">Immersive flow</p>
+                <p className="text-gray-600">
+                  Three thematic rounds move students from literal meaning to lived transformation, mirroring a halaqah lesson
+                  arc.
+                </p>
+              </div>
+              <div className="rounded-lg border border-emerald-100 bg-emerald-50/60 p-3">
+                <p className="font-semibold text-emerald-700">Meaningful lifelines</p>
+                <p className="text-gray-600">
+                  Support tools reward reflection rather than guessing—consult tafsir, journal, then commit to an answer.
+                </p>
+              </div>
+              <div className="rounded-lg border border-amber-100 bg-amber-50/60 p-3">
+                <p className="font-semibold text-amber-700">Actionable outcomes</p>
+                <p className="text-gray-600">
+                  Every question concludes with a prompt and follow-up quest suggestion so insights convert into habits.
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </section>
 
         {gamePanel && (
           <Card className="bg-gradient-to-br from-maroon-600 to-maroon-700 text-white border-0 shadow-xl">

--- a/app/games/tafsir-trivia/page.tsx
+++ b/app/games/tafsir-trivia/page.tsx
@@ -1,0 +1,734 @@
+"use client"
+
+import { useCallback, useMemo, useState } from "react"
+import Link from "next/link"
+import {
+  ArrowLeft,
+  BookOpenCheck,
+  Brain,
+  CheckCircle2,
+  Compass,
+  Flame,
+  HeartPulse,
+  Lightbulb,
+  ListChecks,
+  RotateCcw,
+  Sparkles,
+  Target,
+  Trophy,
+  XCircle,
+} from "lucide-react"
+
+import AppLayout from "@/components/app-layout"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import {
+  TafsirTriviaQuestion,
+  tafsirTriviaDeck,
+  tafsirTriviaRounds,
+} from "@/data/tafsir-trivia"
+
+const TOTAL_HEARTS = 3
+
+const FOUNDATION_COLOR = "bg-sky-50 text-sky-700 border-sky-200"
+const CONTEXT_COLOR = "bg-emerald-50 text-emerald-700 border-emerald-200"
+const APPLICATION_COLOR = "bg-amber-50 text-amber-700 border-amber-200"
+
+type QuestionHistoryEntry = {
+  id: string
+  prompt: string
+  correct: boolean
+  selectedOption: string
+  correctOption: string
+  explanation: string
+  tafsirGem: string
+  reflection: string
+  round: "foundation" | "context" | "application"
+  xpEarned: number
+  hasanatEarned: number
+  usedReflection: boolean
+  usedTafsirGem: boolean
+}
+
+function getRoundColor(round: TafsirTriviaQuestion["round"]): string {
+  switch (round) {
+    case "foundation":
+      return FOUNDATION_COLOR
+    case "context":
+      return CONTEXT_COLOR
+    case "application":
+      return APPLICATION_COLOR
+    default:
+      return "bg-slate-100 text-slate-700 border-slate-200"
+  }
+}
+
+export default function TafsirTriviaGamePage() {
+  const [questionIndex, setQuestionIndex] = useState(0)
+  const [gameComplete, setGameComplete] = useState(false)
+  const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null)
+  const [isSubmitted, setIsSubmitted] = useState(false)
+  const [feedback, setFeedback] = useState<string | null>(null)
+  const [hintVisible, setHintVisible] = useState(false)
+  const [eliminatedOptionIds, setEliminatedOptionIds] = useState<string[]>([])
+  const [reflectionActive, setReflectionActive] = useState(false)
+  const [lifelines, setLifelines] = useState({ tafsirGem: 1, fiftyFifty: 1, reflection: 1 })
+  const [usedGemThisQuestion, setUsedGemThisQuestion] = useState(false)
+  const [usedReflectionThisQuestion, setUsedReflectionThisQuestion] = useState(false)
+
+  const [combo, setCombo] = useState(0)
+  const [bestCombo, setBestCombo] = useState(0)
+  const [streak, setStreak] = useState(0)
+  const [bestStreak, setBestStreak] = useState(0)
+  const [hearts, setHearts] = useState(TOTAL_HEARTS)
+  const [xp, setXp] = useState(0)
+  const [hasanat, setHasanat] = useState(0)
+  const [knowledgeScore, setKnowledgeScore] = useState(0)
+  const [history, setHistory] = useState<QuestionHistoryEntry[]>([])
+
+  const totalQuestions = tafsirTriviaDeck.length
+  const currentQuestion = gameComplete ? null : tafsirTriviaDeck[questionIndex]
+
+  const accuracy = useMemo(() => {
+    if (history.length === 0) return 0
+    const correctCount = history.filter((entry) => entry.correct).length
+    return Math.round((correctCount / history.length) * 100)
+  }, [history])
+
+  const roundRoadmap = useMemo(() => {
+    return tafsirTriviaRounds.map((round) => {
+      const total = tafsirTriviaDeck.filter((question) => question.round === round.id).length
+      const answered = history.filter((entry) => entry.round === round.id).length
+      return {
+        ...round,
+        total,
+        answered,
+      }
+    })
+  }, [history])
+
+  const questionProgress = useMemo(() => {
+    if (gameComplete) return 100
+    const completedCount = history.length
+    return Math.round(((completedCount + (isSubmitted ? 1 : 0)) / totalQuestions) * 100)
+  }, [gameComplete, history, isSubmitted, totalQuestions])
+
+  const remainingThemes = useMemo(() => {
+    if (!currentQuestion) return []
+    return tafsirTriviaDeck.slice(questionIndex + 1).map((question) => ({
+      id: question.id,
+      theme: question.theme,
+      round: question.round,
+      ayahReference: question.ayahReference,
+    }))
+  }, [currentQuestion, questionIndex])
+
+  const handleRevealTafsirGem = useCallback(() => {
+    if (!currentQuestion || lifelines.tafsirGem <= 0 || hintVisible || isSubmitted) return
+    setHintVisible(true)
+    setLifelines((prev) => ({ ...prev, tafsirGem: prev.tafsirGem - 1 }))
+    setUsedGemThisQuestion(true)
+    setFeedback("A tafsir gem has been revealed. Reflect on how it guides your choice.")
+  }, [currentQuestion, hintVisible, isSubmitted, lifelines.tafsirGem])
+
+  const handleFiftyFifty = useCallback(() => {
+    if (!currentQuestion || lifelines.fiftyFifty <= 0 || isSubmitted) return
+    const availableWrongOptions = currentQuestion.options.filter(
+      (option) => !option.isCorrect && !eliminatedOptionIds.includes(option.id),
+    )
+    if (availableWrongOptions.length === 0) return
+    const shuffled = [...availableWrongOptions].sort(() => Math.random() - 0.5)
+    const toEliminate = shuffled.slice(0, Math.min(2, shuffled.length)).map((option) => option.id)
+    setEliminatedOptionIds((prev) => [...prev, ...toEliminate])
+    setLifelines((prev) => ({ ...prev, fiftyFifty: prev.fiftyFifty - 1 }))
+    setFeedback("Two challenging options faded away. Choose with confidence.")
+  }, [currentQuestion, eliminatedOptionIds, isSubmitted, lifelines.fiftyFifty])
+
+  const handleActivateReflection = useCallback(() => {
+    if (!currentQuestion || lifelines.reflection <= 0 || reflectionActive || isSubmitted) return
+    setReflectionActive(true)
+    setUsedReflectionThisQuestion(true)
+    setLifelines((prev) => ({ ...prev, reflection: prev.reflection - 1 }))
+    setFeedback("Pause for reflection. Let the verse speak to your context before answering.")
+  }, [currentQuestion, isSubmitted, lifelines.reflection, reflectionActive])
+
+  const handleSubmit = useCallback(() => {
+    if (!currentQuestion || !selectedOptionId || isSubmitted) return
+    const selectedOption = currentQuestion.options.find((option) => option.id === selectedOptionId)
+    if (!selectedOption) return
+
+    const correctOption = currentQuestion.options.find((option) => option.isCorrect)
+    const isCorrect = selectedOption.isCorrect
+
+    const comboBonus = isCorrect ? combo * 6 : 0
+    const reflectionBonus = isCorrect && usedReflectionThisQuestion ? 10 : 0
+    const hintPenalty = isCorrect && usedGemThisQuestion ? 6 : 0
+    const baseXp = isCorrect ? 40 : 12
+    const baseHasanat = isCorrect ? 24 : 8
+
+    const xpEarned = Math.max(8, baseXp + comboBonus + reflectionBonus - hintPenalty)
+    const hasanatEarned = Math.max(
+      6,
+      baseHasanat + Math.floor(comboBonus / 2) + (usedReflectionThisQuestion ? 5 : 0) - Math.floor(hintPenalty / 2),
+    )
+    const knowledgeEarned = xpEarned + hasanatEarned
+
+    if (isCorrect) {
+      const updatedCombo = combo + 1
+      const updatedStreak = streak + 1
+      setCombo(updatedCombo)
+      setBestCombo((prev) => Math.max(prev, updatedCombo))
+      setStreak(updatedStreak)
+      setBestStreak((prev) => Math.max(prev, updatedStreak))
+      setFeedback("Excellent! Your tafsir intuition is sharpening.")
+    } else {
+      setCombo(0)
+      setStreak(0)
+      setHearts((prev) => Math.max(0, prev - 1))
+      setFeedback("Let's review the insight and strengthen that connection.")
+    }
+
+    setXp((prev) => prev + xpEarned)
+    setHasanat((prev) => prev + hasanatEarned)
+    setKnowledgeScore((prev) => prev + knowledgeEarned)
+
+    setHistory((prev) => [
+      ...prev,
+      {
+        id: currentQuestion.id,
+        prompt: currentQuestion.prompt,
+        correct: isCorrect,
+        selectedOption: selectedOption.text,
+        correctOption: correctOption?.text ?? "",
+        explanation: isCorrect ? selectedOption.rationale : correctOption?.rationale ?? "",
+        tafsirGem: currentQuestion.tafsirGem,
+        reflection: currentQuestion.reflection,
+        round: currentQuestion.round,
+        xpEarned,
+        hasanatEarned,
+        usedReflection: usedReflectionThisQuestion,
+        usedTafsirGem: usedGemThisQuestion,
+      },
+    ])
+
+    setIsSubmitted(true)
+  }, [
+    combo,
+    currentQuestion,
+    isSubmitted,
+    selectedOptionId,
+    streak,
+    usedGemThisQuestion,
+    usedReflectionThisQuestion,
+  ])
+
+  const handleNext = useCallback(() => {
+    if (!isSubmitted) return
+
+    if (questionIndex === totalQuestions - 1) {
+      setGameComplete(true)
+    } else {
+      setQuestionIndex((prev) => prev + 1)
+    }
+
+    setSelectedOptionId(null)
+    setIsSubmitted(false)
+    setHintVisible(false)
+    setEliminatedOptionIds([])
+    setReflectionActive(false)
+    setUsedGemThisQuestion(false)
+    setUsedReflectionThisQuestion(false)
+    setFeedback(null)
+  }, [isSubmitted, questionIndex, totalQuestions])
+
+  const resetGame = useCallback(() => {
+    setQuestionIndex(0)
+    setGameComplete(false)
+    setSelectedOptionId(null)
+    setIsSubmitted(false)
+    setFeedback(null)
+    setHintVisible(false)
+    setEliminatedOptionIds([])
+    setReflectionActive(false)
+    setLifelines({ tafsirGem: 1, fiftyFifty: 1, reflection: 1 })
+    setUsedGemThisQuestion(false)
+    setUsedReflectionThisQuestion(false)
+    setCombo(0)
+    setBestCombo(0)
+    setStreak(0)
+    setBestStreak(0)
+    setHearts(TOTAL_HEARTS)
+    setXp(0)
+    setHasanat(0)
+    setKnowledgeScore(0)
+    setHistory([])
+  }, [])
+
+  const roundBadge = (round: TafsirTriviaQuestion["round"]) => (
+    <Badge variant="outline" className={`capitalize ${getRoundColor(round)}`}>
+      {round}
+    </Badge>
+  )
+
+  return (
+    <AppLayout>
+      <div className="p-6 space-y-6">
+        <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="space-y-3">
+            <Link href="/games" className="inline-flex items-center gap-2 text-sm text-maroon-600 hover:text-maroon-800">
+              <ArrowLeft className="h-4 w-4" /> Back to Habit Quest Arena
+            </Link>
+            <div className="flex items-center gap-3">
+              <h1 className="text-3xl font-bold text-maroon-900">Tafsir Trivia Quest</h1>
+              <Badge className="bg-gradient-to-r from-emerald-500 to-teal-500 text-white border-0">New</Badge>
+            </div>
+            <p className="text-maroon-700 max-w-2xl">
+              Journey through three rounds of tafsir exploration. Decode vocabulary, uncover historical context, and translate
+              each verse into actionable insight. Keep your streak alive to amplify the knowledge multiplier.
+            </p>
+          </div>
+          <div className="flex flex-col items-start gap-3 rounded-2xl border border-maroon-100 bg-maroon-50/60 p-4 text-maroon-700">
+            <div className="flex items-center gap-2 text-sm font-semibold">
+              <Sparkles className="h-4 w-4" /> Learning Goals
+            </div>
+            <ul className="text-sm space-y-1">
+              <li>• Anchor tafsir concepts in vivid Qur&apos;anic themes.</li>
+              <li>• Train reflective habits with guided prompts.</li>
+              <li>• Earn hasanat streaks by answering with intention.</li>
+            </ul>
+          </div>
+        </header>
+
+        <section className="grid gap-6 xl:grid-cols-[2fr,1fr]">
+          <div className="space-y-6">
+            <Card className="border-maroon-100">
+              <CardHeader className="space-y-2">
+                <CardTitle className="flex flex-wrap items-center gap-3 text-maroon-900">
+                  <BookOpenCheck className="h-5 w-5 text-maroon-600" />
+                  {gameComplete ? "Mastery Summary" : currentQuestion?.theme}
+                </CardTitle>
+                <CardDescription className="text-gray-600">
+                  {gameComplete
+                    ? "Review your tafsir journey, reflect on growth areas, and decide your next quest."
+                    : currentQuestion?.learningTarget}
+                </CardDescription>
+                {!gameComplete && currentQuestion && (
+                  <div className="flex flex-wrap items-center gap-3 text-sm text-gray-600">
+                    {roundBadge(currentQuestion.round)}
+                    <span className="inline-flex items-center gap-2">
+                      <Compass className="h-4 w-4 text-maroon-500" /> {currentQuestion.ayahReference}
+                    </span>
+                    <span className="inline-flex items-center gap-2">
+                      <Target className="h-4 w-4 text-maroon-500" /> Question {questionIndex + 1} of {totalQuestions}
+                    </span>
+                  </div>
+                )}
+              </CardHeader>
+
+              {!gameComplete && currentQuestion && (
+                <>
+                  <CardContent className="space-y-6">
+                    <div className="rounded-xl border border-maroon-100 bg-maroon-50/40 p-5 space-y-3">
+                      <p className="text-sm uppercase tracking-wide text-maroon-500 font-semibold">Verse spotlight</p>
+                      <p className="text-2xl font-semibold text-maroon-900">{currentQuestion.excerpt}</p>
+                      <p className="text-maroon-700">{currentQuestion.translation}</p>
+                    </div>
+
+                    <div className="space-y-4">
+                      <p className="text-lg font-semibold text-maroon-900">{currentQuestion.prompt}</p>
+                      <div className="space-y-3">
+                        {currentQuestion.options.map((option, optionIndex) => {
+                          const isEliminated = eliminatedOptionIds.includes(option.id)
+                          const isActive = selectedOptionId === option.id
+                          const isCorrectOption = isSubmitted && option.isCorrect
+                          const isIncorrectSelection =
+                            isSubmitted && option.id === selectedOptionId && !option.isCorrect
+
+                          const baseClasses =
+                            "w-full text-left rounded-xl border p-4 transition-all duration-200 shadow-sm focus:outline-none"
+                          const inactiveClasses =
+                            "bg-white hover:border-maroon-300 hover:shadow-md active:scale-[0.99]"
+                          const activeClasses = "border-maroon-500 bg-maroon-50 ring-2 ring-maroon-200"
+                          const correctClasses = "border-emerald-500 bg-emerald-50 text-emerald-700"
+                          const incorrectClasses = "border-rose-500 bg-rose-50 text-rose-700"
+                          const eliminatedClasses = "border-dashed border-gray-200 bg-gray-50/60 text-gray-400 cursor-not-allowed"
+
+                          let className = `${baseClasses} ${inactiveClasses}`
+                          if (isEliminated) {
+                            className = `${baseClasses} ${eliminatedClasses}`
+                          } else if (isCorrectOption) {
+                            className = `${baseClasses} ${correctClasses}`
+                          } else if (isIncorrectSelection) {
+                            className = `${baseClasses} ${incorrectClasses}`
+                          } else if (isActive) {
+                            className = `${baseClasses} ${activeClasses}`
+                          }
+
+                          return (
+                            <button
+                              key={option.id}
+                              type="button"
+                              disabled={isSubmitted || isEliminated}
+                              onClick={() => {
+                                if (isSubmitted || isEliminated) return
+                                setSelectedOptionId(option.id)
+                                setFeedback(null)
+                              }}
+                              className={className}
+                            >
+                              <div className="flex items-start justify-between gap-4">
+                                <div className="flex items-start gap-3">
+                                  <Badge variant="outline" className="mt-1 border-maroon-200 text-maroon-700">
+                                    {String.fromCharCode(65 + optionIndex)}
+                                  </Badge>
+                                  <div className="space-y-1">
+                                    <p className="font-medium text-maroon-900">{option.text}</p>
+                                    {(isSubmitted || hintVisible) && option.rationale && (
+                                      <p className="text-sm text-gray-600">{option.rationale}</p>
+                                    )}
+                                  </div>
+                                </div>
+                                {isCorrectOption && <CheckCircle2 className="h-5 w-5 text-emerald-500" />}
+                                {isIncorrectSelection && <XCircle className="h-5 w-5 text-rose-500" />}
+                              </div>
+                            </button>
+                          )
+                        })}
+                      </div>
+                    </div>
+
+                    <div className="grid gap-4 md:grid-cols-2">
+                      {(hintVisible || isSubmitted) && (
+                        <div className="rounded-xl border border-emerald-200 bg-emerald-50/60 p-4 space-y-2">
+                          <div className="flex items-center gap-2 text-emerald-700 font-semibold">
+                            <Lightbulb className="h-4 w-4" /> Tafsir Gem
+                          </div>
+                          <p className="text-sm text-emerald-800">{currentQuestion.tafsirGem}</p>
+                          <p className="text-xs text-emerald-700/80">{currentQuestion.scholarVoice}</p>
+                        </div>
+                      )}
+                      {(reflectionActive || isSubmitted) && (
+                        <div className="rounded-xl border border-amber-200 bg-amber-50/70 p-4 space-y-2">
+                          <div className="flex items-center gap-2 text-amber-700 font-semibold">
+                            <Brain className="h-4 w-4" /> Reflection Prompt
+                          </div>
+                          <p className="text-sm text-amber-800">{currentQuestion.reflection}</p>
+                        </div>
+                      )}
+                    </div>
+
+                    {feedback && (
+                      <div className="rounded-xl border border-maroon-200 bg-maroon-50/80 p-4 text-sm text-maroon-700">
+                        {feedback}
+                      </div>
+                    )}
+                  </CardContent>
+
+                  <CardFooter className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                    <div className="text-sm text-gray-600">
+                      {isSubmitted
+                        ? "Explore the tafsir explanation before moving forward."
+                        : "Choose the insight that aligns most with the scholars' commentary."}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {!isSubmitted ? (
+                        <Button
+                          onClick={handleSubmit}
+                          disabled={!selectedOptionId}
+                          className="bg-gradient-to-r from-maroon-600 to-maroon-700 text-white border-0"
+                        >
+                          Lock in answer
+                        </Button>
+                      ) : (
+                        <Button
+                          onClick={handleNext}
+                          className="bg-gradient-to-r from-emerald-500 to-teal-500 text-white border-0"
+                        >
+                          {questionIndex === totalQuestions - 1 ? "View mastery summary" : "Next verse challenge"}
+                        </Button>
+                      )}
+                    </div>
+                  </CardFooter>
+                </>
+              )}
+
+              {gameComplete && (
+                <CardContent className="space-y-6">
+                  <div className="rounded-xl border border-maroon-100 bg-white p-5 space-y-3">
+                    <p className="text-sm uppercase tracking-wide text-maroon-500 font-semibold">Achievement unlocked</p>
+                    <h2 className="text-2xl font-bold text-maroon-900">Tafsir Trailblazer</h2>
+                    <p className="text-maroon-700">
+                      You explored {totalQuestions} verses, activating hope, context, and application. Keep journaling your
+                      reflections to transform knowledge into steady action.
+                    </p>
+                  </div>
+
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div className="rounded-xl border border-emerald-200 bg-emerald-50/70 p-4 space-y-2">
+                      <div className="flex items-center gap-2 text-emerald-700 font-semibold">
+                        <Trophy className="h-4 w-4" /> Performance Highlights
+                      </div>
+                      <ul className="text-sm text-emerald-800 space-y-1">
+                        <li>Knowledge Score: {knowledgeScore} pts</li>
+                        <li>Accuracy: {accuracy}%</li>
+                        <li>Best Streak: {bestStreak} in a row</li>
+                      </ul>
+                    </div>
+                    <div className="rounded-xl border border-amber-200 bg-amber-50/70 p-4 space-y-2">
+                      <div className="flex items-center gap-2 text-amber-700 font-semibold">
+                        <ListChecks className="h-4 w-4" /> Suggested Next Steps
+                      </div>
+                      <ul className="text-sm text-amber-800 space-y-1">
+                        <li>Revisit two journal prompts that stirred the most emotion.</li>
+                        <li>Share one tafsir gem with a study partner today.</li>
+                        <li>Queue up a related habit quest to reinforce application.</li>
+                      </ul>
+                    </div>
+                  </div>
+
+                  <div className="space-y-3">
+                    <div className="flex items-center gap-2 text-sm font-semibold text-maroon-700">
+                      <BookOpenCheck className="h-4 w-4" /> Reflection Journal
+                    </div>
+                    <ScrollArea className="h-64 rounded-xl border border-maroon-100 bg-white p-4">
+                      <div className="space-y-4 text-sm">
+                        {history.map((entry) => (
+                          <div key={entry.id} className="rounded-lg border border-maroon-100 bg-maroon-50/50 p-4 space-y-2">
+                            <div className="flex flex-wrap items-center gap-2 text-xs text-maroon-600 font-semibold">
+                              {roundBadge(entry.round)}
+                              <span>{entry.correct ? "✔ Insight captured" : "✦ Insight to revisit"}</span>
+                              <span>{entry.xpEarned} XP • {entry.hasanatEarned} hasanat</span>
+                            </div>
+                            <p className="font-medium text-maroon-900">{entry.prompt}</p>
+                            <p className="text-maroon-700">Your response: {entry.selectedOption}</p>
+                            {!entry.correct && (
+                              <p className="text-sm text-gray-600">
+                                Correct focus: <span className="font-semibold text-maroon-700">{entry.correctOption}</span>
+                              </p>
+                            )}
+                            <p className="text-sm text-gray-700">{entry.explanation}</p>
+                            <p className="text-xs text-emerald-700">{entry.tafsirGem}</p>
+                            <p className="text-xs text-amber-700">{entry.reflection}</p>
+                          </div>
+                        ))}
+                      </div>
+                    </ScrollArea>
+                  </div>
+                </CardContent>
+              )}
+
+              {gameComplete && (
+                <CardFooter className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <Button asChild variant="outline">
+                    <Link href="/games">Return to Games Hub</Link>
+                  </Button>
+                  <div className="flex items-center gap-2">
+                    <Button variant="ghost" onClick={resetGame} className="gap-2 text-maroon-700">
+                      <RotateCcw className="h-4 w-4" /> Replay challenge
+                    </Button>
+                    <Button className="bg-gradient-to-r from-maroon-600 to-maroon-700 text-white border-0" asChild>
+                      <Link href="/habits">Stack a habit quest</Link>
+                    </Button>
+                  </div>
+                </CardFooter>
+              )}
+            </Card>
+
+            {!gameComplete && (
+              <Card className="border-maroon-100">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-maroon-900">
+                    <Brain className="h-5 w-5 text-maroon-600" /> Power-ups & Lifelines
+                  </CardTitle>
+                  <CardDescription className="text-gray-600">
+                    Use them wisely—each support shapes your final score and reflection depth.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <TooltipProvider>
+                    <div className="grid gap-3 md:grid-cols-3">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="outline"
+                            className="flex h-full flex-col items-start gap-2 rounded-xl border-maroon-200 p-4 text-left"
+                            onClick={handleRevealTafsirGem}
+                            disabled={lifelines.tafsirGem === 0 || hintVisible || isSubmitted}
+                          >
+                            <div className="flex w-full items-center justify-between">
+                              <span className="font-semibold text-maroon-700">Tafsir Gem</span>
+                              <Badge variant="secondary">{lifelines.tafsirGem}</Badge>
+                            </div>
+                            <p className="text-sm text-gray-600">
+                              Reveal a scholar&apos;s insight. Minor XP penalty, major clarity boost.
+                            </p>
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-xs text-sm">
+                          Unlock a classical tafsir highlight to guide your choice. Best for nuanced verses.
+                        </TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="outline"
+                            className="flex h-full flex-col items-start gap-2 rounded-xl border-maroon-200 p-4 text-left"
+                            onClick={handleFiftyFifty}
+                            disabled={lifelines.fiftyFifty === 0 || isSubmitted}
+                          >
+                            <div className="flex w-full items-center justify-between">
+                              <span className="font-semibold text-maroon-700">Option Filter</span>
+                              <Badge variant="secondary">{lifelines.fiftyFifty}</Badge>
+                            </div>
+                            <p className="text-sm text-gray-600">
+                              Remove two distractors. Ideal when choices feel equally strong.
+                            </p>
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-xs text-sm">
+                          Clears away two incorrect options to help you focus on the most accurate tafsir.
+                        </TooltipContent>
+                      </Tooltip>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="outline"
+                            className="flex h-full flex-col items-start gap-2 rounded-xl border-maroon-200 p-4 text-left"
+                            onClick={handleActivateReflection}
+                            disabled={lifelines.reflection === 0 || reflectionActive || isSubmitted}
+                          >
+                            <div className="flex w-full items-center justify-between">
+                              <span className="font-semibold text-maroon-700">Reflection Pause</span>
+                              <Badge variant="secondary">{lifelines.reflection}</Badge>
+                            </div>
+                            <p className="text-sm text-gray-600">
+                              Unlock a journaling cue and bonus hasanat when answered correctly.
+                            </p>
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-xs text-sm">
+                          Activate a guided reflection to deepen application. Earn bonus hasanat when you answer right.
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  </TooltipProvider>
+                </CardContent>
+              </Card>
+            )}
+          </div>
+
+          <div className="space-y-6">
+            <Card className="border-maroon-100">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-maroon-900">
+                  <Flame className="h-5 w-5 text-orange-500" /> Scoreboard
+                </CardTitle>
+                <CardDescription className="text-gray-600">
+                  Maintain your streak to unlock higher multipliers and knowledge combos.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid gap-4 sm:grid-cols-3">
+                  <div className="rounded-xl border border-maroon-100 bg-maroon-50/60 p-4">
+                    <p className="text-xs uppercase tracking-wide text-maroon-500 font-semibold">Knowledge score</p>
+                    <p className="text-2xl font-bold text-maroon-900">{knowledgeScore}</p>
+                    <p className="text-xs text-maroon-600">XP {xp} • Hasanat {hasanat}</p>
+                  </div>
+                  <div className="rounded-xl border border-emerald-100 bg-emerald-50/60 p-4">
+                    <p className="text-xs uppercase tracking-wide text-emerald-600 font-semibold">Streak</p>
+                    <p className="text-2xl font-bold text-emerald-700">{streak}</p>
+                    <p className="text-xs text-emerald-600">Best {bestStreak}</p>
+                  </div>
+                  <div className="rounded-xl border border-amber-100 bg-amber-50/60 p-4">
+                    <p className="text-xs uppercase tracking-wide text-amber-600 font-semibold">Combo</p>
+                    <p className="text-2xl font-bold text-amber-700">{combo}</p>
+                    <p className="text-xs text-amber-600">Peak {bestCombo}</p>
+                  </div>
+                </div>
+
+                <div>
+                  <div className="mb-2 flex items-center justify-between text-xs text-gray-600">
+                    <span>Journey progress</span>
+                    <span>{questionProgress}% complete</span>
+                  </div>
+                  <Progress value={questionProgress} className="h-2" />
+                </div>
+
+                <div className="flex items-center justify-between text-sm text-gray-600">
+                  <span className="flex items-center gap-2">
+                    Hearts
+                    <span className="flex items-center gap-1">
+                      {Array.from({ length: TOTAL_HEARTS }).map((_, index) => (
+                        <HeartPulse
+                          key={index}
+                          className={`h-4 w-4 ${index < hearts ? "text-rose-500" : "text-gray-300"}`}
+                        />
+                      ))}
+                    </span>
+                  </span>
+                  <span className="flex items-center gap-2">Accuracy {accuracy}%</span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="border-maroon-100">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-maroon-900">
+                  <Target className="h-5 w-5 text-maroon-600" /> Round Roadmap
+                </CardTitle>
+                <CardDescription className="text-gray-600">
+                  Track how each tafsir dimension is unfolding across the session.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {roundRoadmap.map((round) => (
+                  <div key={round.id} className="rounded-xl border border-maroon-100 bg-white p-4">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2 text-sm font-semibold text-maroon-700">
+                        {roundBadge(round.id)}
+                        <span>{round.title}</span>
+                      </div>
+                      <span className="text-xs text-gray-500">
+                        {round.answered}/{round.total} complete
+                      </span>
+                    </div>
+                    <p className="mt-2 text-sm text-gray-600">{round.description}</p>
+                    <Progress value={(round.answered / round.total) * 100} className="mt-3 h-1.5" />
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+
+            {!gameComplete && remainingThemes.length > 0 && (
+              <Card className="border-maroon-100">
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-maroon-900">
+                    <Lightbulb className="h-5 w-5 text-amber-500" /> Upcoming themes
+                  </CardTitle>
+                  <CardDescription className="text-gray-600">
+                    Preview the focus of upcoming ayat to prime your mindset.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm text-gray-700">
+                  {remainingThemes.map((theme) => (
+                    <div key={theme.id} className="rounded-lg border border-maroon-100 bg-maroon-50/40 p-3">
+                      <div className="flex items-center justify-between">
+                        <span className="font-medium text-maroon-800">{theme.theme}</span>
+                        {roundBadge(theme.round)}
+                      </div>
+                      <p className="mt-1 text-xs text-gray-600">{theme.ayahReference}</p>
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+            )}
+          </div>
+        </section>
+      </div>
+    </AppLayout>
+  )
+}

--- a/data/tafsir-trivia.ts
+++ b/data/tafsir-trivia.ts
@@ -1,0 +1,451 @@
+export type TafsirTriviaOption = {
+  id: string
+  text: string
+  isCorrect: boolean
+  rationale: string
+}
+
+export type TafsirTriviaQuestion = {
+  id: string
+  round: "foundation" | "context" | "application"
+  theme: string
+  ayahReference: string
+  excerpt: string
+  translation: string
+  prompt: string
+  options: TafsirTriviaOption[]
+  tafsirGem: string
+  scholarVoice: string
+  reflection: string
+  learningTarget: string
+}
+
+export type TafsirTriviaRound = {
+  id: "foundation" | "context" | "application"
+  title: string
+  description: string
+  focus: string
+}
+
+export const tafsirTriviaRounds: TafsirTriviaRound[] = [
+  {
+    id: "foundation",
+    title: "Round 1 • Foundations of Meaning",
+    description:
+      "Check your grasp of core vocabulary and direct meanings before exploring the layers of tafsir.",
+    focus: "Literal translations, key terms, and immediate lessons.",
+  },
+  {
+    id: "context",
+    title: "Round 2 • Contextual Depth",
+    description:
+      "Connect verses to their historical backdrop, reasons of revelation, and classical commentary notes.",
+    focus: "Asbāb al-nuzūl, scholarly insights, and thematic flow.",
+  },
+  {
+    id: "application",
+    title: "Round 3 • Living the Tafsir",
+    description:
+      "Translate the lessons into lived practice by reflecting on character, community, and spiritual growth.",
+    focus: "Personal action steps and contemporary resonance.",
+  },
+]
+
+export const tafsirTriviaDeck: TafsirTriviaQuestion[] = [
+  {
+    id: "foundation_1",
+    round: "foundation",
+    theme: "Praise and Gratitude",
+    ayahReference: "Surah Al-Fātiḥah 1:2",
+    excerpt: "ٱلْحَمْدُ لِلَّهِ رَبِّ ٱلْعَٰلَمِينَ",
+    translation: "All praise is for Allah, Lord of the worlds.",
+    prompt:
+      "Which understanding best captures why Al-Fātiḥah opens with universal praise for Allah as 'Rabb al-ʿĀlamīn'?",
+    options: [
+      {
+        id: "a",
+        text: "It reminds believers that praise is limited to times of ease only.",
+        isCorrect: false,
+        rationale: "The verse emphasizes constant gratitude in all states, not only ease.",
+      },
+      {
+        id: "b",
+        text: "It trains the heart to recognize Allah's nurturing care over every realm of creation.",
+        isCorrect: true,
+        rationale:
+          "Classical exegetes explain 'Rabb' as the One who lovingly nurtures and sustains all worlds.",
+      },
+      {
+        id: "c",
+        text: "It introduces a legal ruling that praise must precede every dua.",
+        isCorrect: false,
+        rationale: "While recommended, scholars do not view this verse as a binding legal command.",
+      },
+      {
+        id: "d",
+        text: "It signals that the surah was revealed specifically for the angels.",
+        isCorrect: false,
+        rationale: "Al-Fātiḥah is described as a guidance manual for humanity, not exclusively angels.",
+      },
+    ],
+    tafsirGem:
+      "Imam Ibn Kathir notes that 'Rabb' combines ownership, nurturing, and gentle reform—teaching us that every blessing is a deliberate gift from our Sustainer.",
+    scholarVoice:
+      "Imam al-Ghazali: 'Gratitude blooms when the servant witnesses the continuous outpour of Allah's care.'",
+    reflection:
+      "List three moments from today where you felt Allah's nurturing care, even in small details.",
+    learningTarget: "Recognize the nurturing qualities embedded within the word 'Rabb'.",
+  },
+  {
+    id: "foundation_2",
+    round: "foundation",
+    theme: "Mercy and Hope",
+    ayahReference: "Surah Az-Zumar 39:53",
+    excerpt: "قُلْ يَٰعِبَادِيَ ٱلَّذِينَ أَسْرَفُواْ عَلَىٰ أَنفُسِهِمْ لَا تَقْنَطُواْ مِن رَّحْمَةِ ٱللَّهِ",
+    translation: "Say, O My servants who have transgressed against themselves, do not despair of Allah's mercy.",
+    prompt:
+      "According to the verse, what is the immediate healing offered to believers who feel overwhelmed by their sins?",
+    options: [
+      {
+        id: "a",
+        text: "An assurance that sincere repentance invites Allah's vast mercy.",
+        isCorrect: true,
+        rationale:
+          "The verse calls the sinner with a compassionate 'O My servants' and commands them never to despair.",
+      },
+      {
+        id: "b",
+        text: "A promise that worldly hardships will instantly disappear.",
+        isCorrect: false,
+        rationale: "Material relief is not guaranteed, but spiritual hope is restored through repentance.",
+      },
+      {
+        id: "c",
+        text: "A reminder that community support outweighs divine forgiveness.",
+        isCorrect: false,
+        rationale: "The focus is on Allah's personal mercy, though community care is beneficial.",
+      },
+      {
+        id: "d",
+        text: "An instruction to delay tawbah until one feels ready.",
+        isCorrect: false,
+        rationale: "Tafsir emphasizes immediate turning back to Allah without postponement.",
+      },
+    ],
+    tafsirGem:
+      "Ibn Ashur highlights that Allah addresses even excessive sinners as 'My servants' to revive their sense of belonging before commanding them to hope.",
+    scholarVoice:
+      "Imam ash-Shawkani: 'The door of mercy remains open regardless of the magnitude of sin, so long as the servant returns.'",
+    reflection:
+      "Write one line of istighfar you can repeat tonight with full presence of heart.",
+    learningTarget: "Anchor repentance in hope rather than shame.",
+  },
+  {
+    id: "foundation_3",
+    round: "foundation",
+    theme: "Trust in Allah",
+    ayahReference: "Surah At-Tawbah 9:51",
+    excerpt: "قُل لَّن يُصِيبَنَا إِلَّا مَا كَتَبَ ٱللَّهُ لَنَا",
+    translation: "Say, nothing will ever befall us except what Allah has decreed for us.",
+    prompt:
+      "What mindset does this verse instill regarding unexpected events?",
+    options: [
+      {
+        id: "a",
+        text: "Every outcome—pleasant or difficult—is written with wisdom meant for our growth.",
+        isCorrect: true,
+        rationale: "The verse nurtures tawakkul by affirming Allah's protective decree over the believer.",
+      },
+      {
+        id: "b",
+        text: "Believers will never experience hardship if they have strong iman.",
+        isCorrect: false,
+        rationale: "Trials remain part of life; the verse reframes them, it does not erase them.",
+      },
+      {
+        id: "c",
+        text: "We should avoid making future plans altogether.",
+        isCorrect: false,
+        rationale: "Islam encourages planning while trusting Allah, not abandoning effort.",
+      },
+      {
+        id: "d",
+        text: "Destiny removes personal responsibility for choices.",
+        isCorrect: false,
+        rationale: "Qadar and accountability co-exist; tafsir warns against fatalism.",
+      },
+    ],
+    tafsirGem:
+      "Al-Qurtubi explains that the phrase 'kataba Allahu lana' means the decree is ultimately in our favor, even if wrapped in difficulty.",
+    scholarVoice:
+      "Ibn al-Qayyim: 'True reliance is to exert effort, then rest the heart upon the wisdom of the decree.'",
+    reflection:
+      "Pair this verse with a current worry. How could trusting Allah reshape your response?",
+    learningTarget: "Develop resilience rooted in tawakkul.",
+  },
+  {
+    id: "context_1",
+    round: "context",
+    theme: "Brotherhood After Conflict",
+    ayahReference: "Surah Al-Ḥujurāt 49:10",
+    excerpt: "إِنَّمَا ٱلْمُؤْمِنُونَ إِخْوَةٌ فَأَصْلِحُواْ بَيْنَ أَخَوَيْكُمْ",
+    translation: "The believers are but brothers, so make peace between your brothers.",
+    prompt:
+      "What historical scenario shaped the revelation of this verse according to classical reports?",
+    options: [
+      {
+        id: "a",
+        text: "A dispute erupted between two Muslim tribes in Madinah requiring community mediation.",
+        isCorrect: true,
+        rationale:
+          "Narrations mention tension between the Aws and Khazraj, prompting direct guidance on reconciliation.",
+      },
+      {
+        id: "b",
+        text: "A treaty negotiation with the Quraysh in Makkah.",
+        isCorrect: false,
+        rationale: "The verse addressed intra-Muslim tensions rather than external diplomacy.",
+      },
+      {
+        id: "c",
+        text: "A disagreement between angels regarding the virtues of prophets.",
+        isCorrect: false,
+        rationale: "Reports specifically mention human tribes, not celestial debates.",
+      },
+      {
+        id: "d",
+        text: "An argument about inheritance between two Makkan families.",
+        isCorrect: false,
+        rationale: "The asbāb focus on the Medinan community dealing with post-battle sensitivities.",
+      },
+    ],
+    tafsirGem:
+      "Imam as-Sa'di writes that genuine brotherhood requires actively repairing harm, not passively hoping for harmony.",
+    scholarVoice:
+      "Shaykh Abd ar-Rahman al-Barrak: 'Reconciliation is a collective duty when unity is threatened.'",
+    reflection:
+      "Identify one strained relationship and jot down a first compassionate step toward mending it.",
+    learningTarget: "Link community harmony to direct divine instruction.",
+  },
+  {
+    id: "context_2",
+    round: "context",
+    theme: "Night Journey Inspiration",
+    ayahReference: "Surah Al-Isrā’ 17:1",
+    excerpt: "سُبْحَٰنَ ٱلَّذِى أَسْرَىٰ بِعَبْدِهِ لَيْلًا",
+    translation: "Glory be to the One who took His servant by night...",
+    prompt:
+      "How did the miracle of the Night Journey strengthen early believers according to tafsir?",
+    options: [
+      {
+        id: "a",
+        text: "It reaffirmed that spiritual openings can arrive after periods of intense hardship.",
+        isCorrect: true,
+        rationale:
+          "The Isra' occurred after the Year of Sorrow, providing profound consolation and renewed mission.",
+      },
+      {
+        id: "b",
+        text: "It taught that prayer should be delayed until sunrise.",
+        isCorrect: false,
+        rationale: "The verse glorifies Allah and mentions the journey; it does not legislate prayer timings here.",
+      },
+      {
+        id: "c",
+        text: "It required believers to relocate to Jerusalem immediately.",
+        isCorrect: false,
+        rationale: "No instruction to migrate is mentioned in this context.",
+      },
+      {
+        id: "d",
+        text: "It discouraged the Prophet ﷺ from sharing miracles with the community.",
+        isCorrect: false,
+        rationale: "In fact, the Prophet ﷺ described the journey, leading to Abu Bakr's famous declaration of truthfulness.",
+      },
+    ],
+    tafsirGem:
+      "Imam an-Nasafi comments that Allah begins with 'Subhan' to remind listeners that the journey transcends human limitations.",
+    scholarVoice:
+      "Ibn Kathir: 'When the Prophet recounted the Isra', Abu Bakr instantly affirmed him, earning the title as-Siddiq.'",
+    reflection:
+      "Recall a moment when a friend's faith statement lifted your own certainty. How can you reciprocate that support?",
+    learningTarget: "Draw courage from the Isra' narrative during personal tests.",
+  },
+  {
+    id: "context_3",
+    round: "context",
+    theme: "Justice with Families",
+    ayahReference: "Surah An-Nisā’ 4:135",
+    excerpt: "يَٰأَيُّهَا ٱلَّذِينَ ءَامَنُواْ كُونُواْ قَوَّٰمِينَ بِٱلْقِسْطِ شُهَدَآءَ لِلَّهِ وَلَوْ عَلَىٰ أَنفُسِكُمْ",
+    translation:
+      "O believers, stand firm for justice as witnesses for Allah, even against yourselves or your parents and relatives.",
+    prompt:
+      "Which legal ethic do mufassirun extract from this powerful instruction?",
+    options: [
+      {
+        id: "a",
+        text: "Justice must be upheld even when it disadvantages one's own family ties.",
+        isCorrect: true,
+        rationale:
+          "The verse explicitly commands fairness over personal interest, a cornerstone in Islamic legal integrity.",
+      },
+      {
+        id: "b",
+        text: "Witnesses can refuse testimony if family might be embarrassed.",
+        isCorrect: false,
+        rationale: "Shyness or shame is not an excuse to abandon justice.",
+      },
+      {
+        id: "c",
+        text: "Financial cases are exempt from the demand of justice.",
+        isCorrect: false,
+        rationale: "Tafsir applies this verse broadly, especially to financial and legal matters.",
+      },
+      {
+        id: "d",
+        text: "The verse only applied during the Prophet's lifetime.",
+        isCorrect: false,
+        rationale: "Scholars view it as enduring guidance for all Muslim societies.",
+      },
+    ],
+    tafsirGem:
+      "Imam Fakhr ad-Din ar-Razi explains that justice for Allah's sake means emotions cannot override testimony for truth.",
+    scholarVoice:
+      "Shaykh al-Alusi: 'Standing firm implies repeating the commitment daily, not just during court cases.'",
+    reflection:
+      "Where might bias cloud your judgment this week? Note one concrete correction you can make.",
+    learningTarget: "Champion principled justice in family dynamics.",
+  },
+  {
+    id: "application_1",
+    round: "application",
+    theme: "Service and Compassion",
+    ayahReference: "Surah Al-Māʿūn 107:3-4",
+    excerpt: "وَلَا يَحُضُّ عَلَىٰ طَعَامِ ٱلْمِسْكِينِ فَوَيْلٌ لِّلْمُصَلِّينَ",
+    translation: "And they do not encourage feeding the poor – so woe to those who pray (yet neglect this duty).",
+    prompt:
+      "How should this verse transform our approach to acts of worship?",
+    options: [
+      {
+        id: "a",
+        text: "Salah must be coupled with social concern, otherwise it becomes hollow ritual.",
+        isCorrect: true,
+        rationale:
+          "Tafsir Ibn Kathir warns against prayer devoid of compassion for society's vulnerable.",
+      },
+      {
+        id: "b",
+        text: "Charity is optional as long as prayers are on time.",
+        isCorrect: false,
+        rationale: "The surah condemns withholding kindness, showing it's integral to sincere faith.",
+      },
+      {
+        id: "c",
+        text: "Believers should postpone salah until community service is complete.",
+        isCorrect: false,
+        rationale: "Islam integrates both duties; one does not cancel the other.",
+      },
+      {
+        id: "d",
+        text: "The ayah only censures those who miss zakah payments.",
+        isCorrect: false,
+        rationale: "It targets a broader neglect of the needy and lack of empathy.",
+      },
+    ],
+    tafsirGem:
+      "Al-Tabari states that failing to encourage feeding the needy reveals a heart untouched by the humility of salah.",
+    scholarVoice:
+      "Shaykh Sa'id Hawwa: 'Prayer without service is like a body without spirit.'",
+    reflection:
+      "Schedule one act of quiet service this week that no one knows about but Allah.",
+    learningTarget: "Fuse worship with compassionate action.",
+  },
+  {
+    id: "application_2",
+    round: "application",
+    theme: "Environmental Stewardship",
+    ayahReference: "Surah Al-A'raf 7:56",
+    excerpt: "وَلَا تُفْسِدُوا فِي ٱلْأَرْضِ بَعْدَ إِصْلَٰحِهَا",
+    translation: "Do not cause corruption on the earth after it has been set right.",
+    prompt:
+      "Which contemporary habit aligns with the tafsir principle of preserving Allah's balance on earth?",
+    options: [
+      {
+        id: "a",
+        text: "Reducing waste and honoring resources as trusts from Allah.",
+        isCorrect: true,
+        rationale:
+          "Scholars extend the command to modern forms of corruption including environmental neglect.",
+      },
+      {
+        id: "b",
+        text: "Excessive consumption as a sign of gratitude.",
+        isCorrect: false,
+        rationale: "Israf contradicts gratitude and harms the earth's balance.",
+      },
+      {
+        id: "c",
+        text: "Limiting du'a to Masjid settings only.",
+        isCorrect: false,
+        rationale: "The verse addresses societal conduct, not the location of du'a.",
+      },
+      {
+        id: "d",
+        text: "Avoiding any form of urban development.",
+        isCorrect: false,
+        rationale: "The verse prohibits corruption, not constructive development that serves communities.",
+      },
+    ],
+    tafsirGem:
+      "Ibn Kathir relates that sowing corruption includes unjust consumption of resources and disrupting ecosystems entrusted to us.",
+    scholarVoice:
+      "Mufti Menk: 'Caring for the earth is part of worship; it reflects appreciation of the Creator's gifts.'",
+    reflection:
+      "Audit your daily routine for one habit you can adjust to reduce waste.",
+    learningTarget: "Adopt eco-conscious habits as spiritual responsibility.",
+  },
+  {
+    id: "application_3",
+    round: "application",
+    theme: "Resilience and Patience",
+    ayahReference: "Surah Ash-Sharḥ 94:7-8",
+    excerpt: "فَإِذَا فَرَغْتَ فَٱنصَبْ وَإِلَىٰ رَبِّكَ فَٱرْغَب",
+    translation: "So when you are free, then strive hard, and to your Lord turn your desire.",
+    prompt:
+      "What practical rhythm do scholars encourage based on these verses?",
+    options: [
+      {
+        id: "a",
+        text: "Cycle between purposeful effort and heartfelt devotion, never drifting into aimlessness.",
+        isCorrect: true,
+        rationale:
+          "Tafsir scholars describe a believer transitioning from one beneficial endeavor to another while renewing intention.",
+      },
+      {
+        id: "b",
+        text: "Work intensely for a year, then rest entirely for another year.",
+        isCorrect: false,
+        rationale: "The verse calls for consistent effort, not prolonged abandonment.",
+      },
+      {
+        id: "c",
+        text: "Detach worship from work responsibilities.",
+        isCorrect: false,
+        rationale: "The verse integrates both, guiding believers to turn to Allah through and after their tasks.",
+      },
+      {
+        id: "d",
+        text: "Reserve du'a only for emergencies.",
+        isCorrect: false,
+        rationale: "The verse nurtures continuous yearning towards Allah, not sporadic devotion.",
+      },
+    ],
+    tafsirGem:
+      "Imam ash-Shanqiti interprets 'fansab' as engaging with the next act of worship or service energetically once one task concludes.",
+    scholarVoice:
+      "Imam al-Biqā'i: 'Your heart should always have a destination: longing for your Lord.'",
+    reflection:
+      "Plan a mini-ritual to transition from daily work into evening worship with presence.",
+    learningTarget: "Design sustainable rhythms of effort and devotion.",
+  },
+]


### PR DESCRIPTION
## Summary
- add a dedicated Tafsir Trivia quest page with lifelines, scoring, and reflection journaling
- seed a curated tafsir trivia deck with multi-round metadata for the game flow
- spotlight the new experience on the games hub with a brainstorm card and launch entry point

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ad2934bc832788f934fac7838933