### PR TITLE
Handle missing Mushaf assets and disabled transcription gracefully

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,16 +3,6 @@
 
 @custom-variant dark (&:is(.dark *));
 
-@font-face {
-  font-family: "Mushaf Madinah";
-  src:
-    url("/fonts/mushaf/mushaf-madinah.woff2") format("woff2"),
-    url("/fonts/mushaf/mushaf-madinah.woff") format("woff");
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
-
 :root {
   /* Updated theme to match Islamic educational platform with maroon and cream colors */
   --background: oklch(0.98 0.01 45); /* Warm cream background */

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,0 +1,30 @@
+import { ImageResponse } from "next/og"
+
+export const size = { width: 64, height: 64 }
+export const contentType = "image/png"
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          alignItems: "center",
+          background: "linear-gradient(135deg, #5b1d2c 0%, #8c2f45 45%, #d4af37 100%)",
+          borderRadius: "16px",
+          color: "#fdf7e3",
+          display: "flex",
+          fontSize: 36,
+          fontWeight: 700,
+          height: "100%",
+          justifyContent: "center",
+          width: "100%",
+        }}
+      >
+        أ
+      </div>
+    ),
+    {
+      ...size,
+    },
+  )
+}

--- a/components/recitation/mobile-recitation-client.tsx
+++ b/components/recitation/mobile-recitation-client.tsx
@@ -21,6 +21,8 @@ export interface MobileRecitationClientProps {
   overlayMode: MushafOverlayMode
   permissionStatus: "unknown" | "granted" | "denied"
   errorMessage?: string | null
+  isLiveAnalysisSupported: boolean
+  unavailableMessage?: string
   className?: string
 }
 
@@ -35,6 +37,8 @@ export function MobileRecitationClient({
   overlayMode,
   permissionStatus,
   errorMessage,
+  isLiveAnalysisSupported,
+  unavailableMessage,
   className,
 }: MobileRecitationClientProps) {
   const normalizedVolume = Math.min(1, Math.max(volumeLevel, 0))
@@ -78,12 +82,13 @@ export function MobileRecitationClient({
             onClick={onToggle}
             size="icon"
             className={cn(
-              "relative z-10 h-full w-full rounded-full border-0 text-white shadow-xl transition-all",
+              "relative z-10 h-full w-full rounded-full border-0 text-white shadow-xl transition-all disabled:cursor-not-allowed disabled:opacity-60",
               isRecording
                 ? "bg-gradient-to-br from-emerald-500 to-emerald-600 hover:from-emerald-500 hover:to-emerald-600"
                 : "bg-gradient-to-br from-primary to-primary/90 hover:from-primary/90 hover:to-primary",
             )}
             aria-label={isRecording ? "Stop live recitation" : "Start live recitation"}
+            disabled={!isLiveAnalysisSupported}
           >
             {isRecording ? <MicOff className="h-10 w-10" /> : <Mic className="h-10 w-10" />}
           </Button>
@@ -97,9 +102,12 @@ export function MobileRecitationClient({
             </p>
           ) : (
             <p className="text-xs text-muted-foreground">
-              {isLiveAnalysisActive
-                ? "Speak clearly and maintain a steady pace."
-                : "Tap the button to begin tajweed analysis."}
+              {!isLiveAnalysisSupported
+                ? unavailableMessage ||
+                  "AI transcription isn't configured on this server yet. Add an OPENAI_API_KEY and refresh."
+                : isLiveAnalysisActive
+                  ? "Speak clearly and maintain a steady pace."
+                  : "Tap the button to begin tajweed analysis."}
             </p>
           )}
         </div>

--- a/hooks/useMushafFontLoader.ts
+++ b/hooks/useMushafFontLoader.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react"
 
-import { MUSHAF_FONT_SOURCES, resolveMushafFontUrl } from "@/lib/mushaf-fonts"
+import { MUSHAF_FONT_SOURCES, MUSHAF_FONTS_AVAILABLE, resolveMushafFontUrl } from "@/lib/mushaf-fonts"
 
 export type MushafFontStatus = "idle" | "loading" | "ready" | "error"
 
@@ -10,9 +10,25 @@ export function useMushafFontLoader(enabled: boolean): { status: MushafFontStatu
   const [status, setStatus] = useState<MushafFontStatus>("idle")
   const [error, setError] = useState<string | null>(null)
 
-  const shouldAttemptLoad = useMemo(() => enabled && typeof window !== "undefined" && "fonts" in document, [enabled])
+  const shouldAttemptLoad = useMemo(() => {
+    return enabled && MUSHAF_FONTS_AVAILABLE && typeof window !== "undefined" && "fonts" in document
+  }, [enabled])
 
   useEffect(() => {
+    if (!enabled) {
+      setStatus("idle")
+      setError(null)
+      return
+    }
+
+    if (!MUSHAF_FONTS_AVAILABLE) {
+      setStatus("error")
+      setError(
+        "Mushaf font assets are not installed on this server yet. Run `npm run fonts:mushaf` and convert the TTX exports to WOFF/WOFF2.",
+      )
+      return
+    }
+
     if (!shouldAttemptLoad) {
       return
     }
@@ -58,7 +74,7 @@ export function useMushafFontLoader(enabled: boolean): { status: MushafFontStatu
     return () => {
       isCancelled = true
     }
-  }, [shouldAttemptLoad])
+  }, [enabled, shouldAttemptLoad])
 
   return { status, isReady: status === "ready", error }
 }

--- a/lib/mushaf-fonts.ts
+++ b/lib/mushaf-fonts.ts
@@ -27,6 +27,8 @@ export const MUSHAF_FONT_SOURCES: MushafFontSource[] = [
 
 export const MUSHAF_FONT_PUBLIC_PATH = "/fonts/mushaf"
 
+export const MUSHAF_FONTS_AVAILABLE = process.env.NEXT_PUBLIC_MUSHAF_FONTS_READY === "true"
+
 export function resolveMushafFontUrl(source: MushafFontSource): string {
   return `${MUSHAF_FONT_PUBLIC_PATH}/${source.file}`
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,20 @@
+import fs from "node:fs"
+import path from "node:path"
+
+const requiredMushafFonts = ["mushaf-madinah.woff2", "mushaf-madinah.woff"]
+const mushafFontDirectory = path.join(process.cwd(), "public", "fonts", "mushaf")
+
+const mushafFontsReady = requiredMushafFonts.every((file) => {
+  try {
+    const candidate = path.join(mushafFontDirectory, file)
+    return fs.existsSync(candidate) && fs.statSync(candidate).isFile()
+  } catch {
+    return false
+  }
+})
+
+const transcriptionEnabled = typeof process.env.OPENAI_API_KEY === "string" && process.env.OPENAI_API_KEY.length > 0
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   eslint: {
@@ -10,6 +27,10 @@ const nextConfig = {
     unoptimized: true,
   },
   output: "standalone",
+  env: {
+    NEXT_PUBLIC_MUSHAF_FONTS_READY: mushafFontsReady ? "true" : "false",
+    NEXT_PUBLIC_TRANSCRIPTION_ENABLED: transcriptionEnabled ? "true" : "false",
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- detect the presence of converted Mushaf fonts and OpenAI credentials during build and expose them to the client
- gate the Mushaf typography switch and live transcription workflow behind the new feature flags with clearer fallbacks and mobile support
- remove the hard-coded font-face declarations that produced 404s and add a generated favicon icon to satisfy Next.js asset requests

## Testing
- npm run lint *(fails: pre-existing lint errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c5f4e6e883278348cd577f55ccce