### PR TITLE
Improve tajweed lab resilience and font loading

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,16 +3,6 @@
 
 @custom-variant dark (&:is(.dark *));
 
-@font-face {
-  font-family: "Mushaf Madinah";
-  src:
-    url("/fonts/mushaf/mushaf-madinah.woff2") format("woff2"),
-    url("/fonts/mushaf/mushaf-madinah.woff") format("woff");
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
-
 :root {
   /* Updated theme to match Islamic educational platform with maroon and cream colors */
   --background: oklch(0.98 0.01 45); /* Warm cream background */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,6 +19,9 @@ export const metadata: Metadata = {
     "Advanced platform for Qur'an recitation, memorization, and Islamic education with AI-powered feedback and comprehensive teacher tools.",
   generator: "AlFawz Qur'an Institute",
   keywords: ["Quran", "Islamic Education", "Memorization", "Recitation", "Tajweed", "Hifz"],
+  icons: {
+    icon: "/favicon.ico",
+  },
 }
 
 export default function RootLayout({
@@ -31,6 +34,7 @@ export default function RootLayout({
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link rel="icon" href="/favicon.ico" />
         <link
           href="https://fonts.googleapis.com/css2?family=Amiri:ital,wght@0,400;0,700;1,400;1,700&family=Scheherazade+New:wght@400;500;600;700&family=Noto+Naskh+Arabic:wght@400;500;600;700&family=Reem+Kufi:wght@400;500;600;700&display=swap"
           rel="stylesheet"

--- a/hooks/useMushafFontLoader.ts
+++ b/hooks/useMushafFontLoader.ts
@@ -10,7 +10,10 @@ export function useMushafFontLoader(enabled: boolean): { status: MushafFontStatu
   const [status, setStatus] = useState<MushafFontStatus>("idle")
   const [error, setError] = useState<string | null>(null)
 
-  const shouldAttemptLoad = useMemo(() => enabled && typeof window !== "undefined" && "fonts" in document, [enabled])
+  const shouldAttemptLoad = useMemo(
+    () => enabled && typeof window !== "undefined" && "fonts" in document && "FontFace" in window,
+    [enabled],
+  )
 
   useEffect(() => {
     if (!shouldAttemptLoad) {
@@ -24,13 +27,30 @@ export function useMushafFontLoader(enabled: boolean): { status: MushafFontStatu
       setError(null)
 
       try {
+        const missingSources: string[] = []
+
         await Promise.all(
           MUSHAF_FONT_SOURCES.map(async (source) => {
             if (document.fonts.check(`1em ${source.family}`)) {
               return
             }
 
-            const fontFace = new FontFace(source.family, `url(${resolveMushafFontUrl(source)}) format("${source.format}")`, {
+            const fontUrl = resolveMushafFontUrl(source)
+
+            if (typeof fetch === "function") {
+              try {
+                const response = await fetch(fontUrl, { method: "HEAD" })
+                if (!response.ok) {
+                  missingSources.push(source.file)
+                  return
+                }
+              } catch {
+                missingSources.push(source.file)
+                return
+              }
+            }
+
+            const fontFace = new FontFace(source.family, `url(${fontUrl}) format("${source.format}")`, {
               weight: source.weight.toString(),
               style: source.style,
               display: "swap",
@@ -41,6 +61,13 @@ export function useMushafFontLoader(enabled: boolean): { status: MushafFontStatu
           }),
         )
 
+        if (missingSources.length > 0) {
+          const missingList = missingSources.join(", ")
+          throw new Error(
+            `Missing Mushaf font asset${missingSources.length === 1 ? "" : "s"}: ${missingList}. Run \`npm run fonts:mushaf\` and convert the exported TTX files to WOFF/WOFF2 to enable Mushaf typography.`,
+          )
+        }
+
         if (!isCancelled) {
           setStatus("ready")
         }
@@ -48,7 +75,11 @@ export function useMushafFontLoader(enabled: boolean): { status: MushafFontStatu
         console.error("Failed to load Mushaf fonts", caught)
         if (!isCancelled) {
           setStatus("error")
-          setError(caught instanceof Error ? caught.message : "Unable to load Mushaf font assets")
+          setError(
+            caught instanceof Error
+              ? caught.message
+              : "Unable to load Mushaf font assets. Run `npm run fonts:mushaf` to download the required files.",
+          )
         }
       }
     }


### PR DESCRIPTION
## Summary
- harden the recitation lab speech recognition flow to restart on benign errors and surface actionable messages when capture fails
- guard Mushaf font loading by checking asset availability, reporting actionable guidance, and stop preloading missing font files
- expose the favicon through metadata and markup to prevent 404s during app startup

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c706ea5083279fe65161541b0fb0