### PR TITLE
Implement low-latency microphone streaming for live tajweed

### DIFF
--- a/app/dashboard/student/reader/components/LiveAnalysisModal.tsx
+++ b/app/dashboard/student/reader/components/LiveAnalysisModal.tsx
@@ -112,13 +112,13 @@ export function LiveAnalysisModal({
 
   useEffect(() => {
     if (open) {
-      start()
+      void start()
     } else {
-      stop()
+      void stop()
     }
     // stop recorder when unmounting modal
     return () => {
-      stop()
+      void stop()
     }
   }, [open, start, stop])
 
@@ -199,9 +199,9 @@ export function LiveAnalysisModal({
                     size="sm"
                     onClick={() => {
                       if (status === "listening" || status === "processing") {
-                        stop()
+                        void stop()
                       } else {
-                        start()
+                        void start()
                       }
                     }}
                   >

--- a/app/dashboard/student/reader/hooks/useLiveRecitation.ts
+++ b/app/dashboard/student/reader/hooks/useLiveRecitation.ts
@@ -487,10 +487,10 @@ export function useLiveRecitation(
     onVolume: handleVolume,
   })
 
-  const stopRecordingInternal = useCallback(() => {
+  const stopRecordingInternal = useCallback(async () => {
     if (captureModeRef.current === "microphone-stream") {
       flushPendingFrames()
-      stopStream()
+      await stopStream()
       captureModeRef.current = null
       setCaptureMode(null)
       setStatus((prev) => (prev === "error" ? prev : "idle"))
@@ -612,8 +612,8 @@ export function useLiveRecitation(
     }
   }, [chunkDurationMs, enqueueChunk, isStreamActive, isStreamSupported, startStream])
 
-  const stop = useCallback(() => {
-    stopRecordingInternal()
+  const stop = useCallback(async () => {
+    await stopRecordingInternal()
   }, [stopRecordingInternal])
 
   const reset = useCallback(() => {
@@ -635,7 +635,7 @@ export function useLiveRecitation(
     mountedRef.current = true
     return () => {
       mountedRef.current = false
-      stopRecordingInternal()
+      void stopRecordingInternal()
     }
   }, [stopRecordingInternal])
 

--- a/hooks/useMicrophoneStream.ts
+++ b/hooks/useMicrophoneStream.ts
@@ -11,7 +11,7 @@ export interface MicrophoneFrameMetadata {
 
 export interface UseMicrophoneStreamOptions {
   /**
-   * Buffer size in samples for the underlying ScriptProcessorNode. Smaller buffers
+   * Buffer size in samples for the underlying processor node. Smaller buffers
    * yield lower latency but require more frequent processing.
    */
   bufferSize?: 256 | 512 | 1024 | 2048 | 4096
@@ -37,7 +37,7 @@ export interface UseMicrophoneStreamResult {
   /** Begin streaming audio from the user's microphone. */
   start: () => Promise<{ stream: MediaStream; sampleRate: number }>
   /** Stop streaming audio and release all audio resources. */
-  stop: () => void
+  stop: () => Promise<void>
   /** Whether the microphone stream is currently active. */
   isActive: boolean
   /** Whether microphone streaming is supported in the current browser. */
@@ -58,12 +58,20 @@ export interface UseMicrophoneStreamResult {
 
 type AudioContextConstructor = typeof AudioContext
 
+type NextWindow = typeof window & {
+  __NEXT_DATA__?: {
+    assetPrefix?: string
+  }
+}
+
 const defaultConstraints: MediaTrackConstraints = {
   channelCount: 1,
   echoCancellation: true,
   noiseSuppression: true,
   autoGainControl: true,
 }
+
+const WORKLET_MODULE_PATH = "/audio-worklets/microphone-processor.js"
 
 export function useMicrophoneStream(options: UseMicrophoneStreamOptions = {}): UseMicrophoneStreamResult {
   const [permission, setPermission] = useState<MicrophonePermissionStatus>("unknown")
@@ -74,11 +82,15 @@ export function useMicrophoneStream(options: UseMicrophoneStreamOptions = {}): U
 
   const streamRef = useRef<MediaStream | null>(null)
   const audioContextRef = useRef<AudioContext | null>(null)
-  const processorRef = useRef<ScriptProcessorNode | null>(null)
-  const gainRef = useRef<GainNode | null>(null)
+  const scriptProcessorRef = useRef<ScriptProcessorNode | null>(null)
+  const workletRef = useRef<AudioWorkletNode | null>(null)
+  const sourceNodeRef = useRef<MediaStreamAudioSourceNode | null>(null)
+  const gainNodeRef = useRef<GainNode | null>(null)
   const volumeRef = useRef(0)
   const frameCallbackRef = useRef<UseMicrophoneStreamOptions["onAudioFrame"]>()
   const volumeCallbackRef = useRef<UseMicrophoneStreamOptions["onVolume"]>()
+  const pendingFlushResolverRef = useRef<(() => void) | null>(null)
+  const pendingFlushTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const bufferSize = options.bufferSize ?? 2048
   const smoothing = options.smoothing ?? 0.25
@@ -96,20 +108,100 @@ export function useMicrophoneStream(options: UseMicrophoneStreamOptions = {}): U
       return false
     }
     const hasMedia = typeof navigator !== "undefined" && !!navigator.mediaDevices?.getUserMedia
-    const AudioCtx = (window.AudioContext ?? (window as unknown as { webkitAudioContext?: AudioContextConstructor }).webkitAudioContext)
+    const AudioCtx =
+      window.AudioContext ?? (window as unknown as { webkitAudioContext?: AudioContextConstructor }).webkitAudioContext
     return hasMedia && typeof AudioCtx === "function"
   }, [])
 
-  const cleanup = useCallback(() => {
-    processorRef.current?.disconnect()
-    processorRef.current = null
+  const clearFlushTimeout = useCallback(() => {
+    if (pendingFlushTimeoutRef.current) {
+      clearTimeout(pendingFlushTimeoutRef.current)
+      pendingFlushTimeoutRef.current = null
+    }
+  }, [])
 
-    gainRef.current?.disconnect()
-    gainRef.current = null
+  const processAudioFrame = useCallback(
+    (frame: Float32Array, rate: number, timestamp?: number) => {
+      if (!frame || frame.length === 0 || !Number.isFinite(rate)) {
+        return
+      }
+
+      const metadata: MicrophoneFrameMetadata = {
+        sampleRate: rate,
+        timestamp: typeof timestamp === "number" ? timestamp : performance.now(),
+      }
+
+      frameCallbackRef.current?.(frame, metadata)
+
+      let sum = 0
+      for (let index = 0; index < frame.length; index += 1) {
+        const value = frame[index]
+        sum += value * value
+      }
+
+      const rms = Math.sqrt(sum / frame.length)
+      const previous = volumeRef.current
+      const nextVolume = smoothing * previous + (1 - smoothing) * rms
+      volumeRef.current = nextVolume
+
+      if (Number.isFinite(nextVolume) && Math.abs(nextVolume - previous) > 0.01) {
+        setVolume(nextVolume)
+        volumeCallbackRef.current?.(nextVolume)
+      }
+    },
+    [smoothing],
+  )
+
+  const cleanup = useCallback(() => {
+    clearFlushTimeout()
+    pendingFlushResolverRef.current = null
+
+    if (workletRef.current) {
+      try {
+        workletRef.current.port.onmessage = null
+      } catch (caught) {
+        console.warn("Failed to detach microphone worklet listener", caught)
+      }
+      try {
+        workletRef.current.disconnect()
+      } catch {
+        // ignore errors during disconnect
+      }
+      workletRef.current = null
+    }
+
+    if (scriptProcessorRef.current) {
+      try {
+        scriptProcessorRef.current.disconnect()
+      } catch {
+        // ignore
+      }
+      scriptProcessorRef.current.onaudioprocess = null
+      scriptProcessorRef.current = null
+    }
+
+    if (gainNodeRef.current) {
+      try {
+        gainNodeRef.current.disconnect()
+      } catch {
+        // ignore
+      }
+      gainNodeRef.current = null
+    }
+
+    if (sourceNodeRef.current) {
+      try {
+        sourceNodeRef.current.disconnect()
+      } catch {
+        // ignore
+      }
+      sourceNodeRef.current = null
+    }
 
     if (audioContextRef.current) {
-      audioContextRef.current.close().catch(() => undefined)
+      const context = audioContextRef.current
       audioContextRef.current = null
+      context.close().catch(() => undefined)
     }
 
     if (streamRef.current) {
@@ -121,11 +213,38 @@ export function useMicrophoneStream(options: UseMicrophoneStreamOptions = {}): U
     setSampleRate(null)
     volumeRef.current = 0
     setVolume(0)
-  }, [])
+  }, [clearFlushTimeout])
 
-  const stop = useCallback(() => {
+  const stop = useCallback(async () => {
+    if (workletRef.current) {
+      try {
+        const flushPromise = new Promise<void>((resolve) => {
+          pendingFlushResolverRef.current = resolve
+          pendingFlushTimeoutRef.current = setTimeout(() => {
+            const fallback = pendingFlushResolverRef.current
+            pendingFlushResolverRef.current = null
+            clearFlushTimeout()
+            fallback?.()
+          }, 120)
+        })
+
+        try {
+          workletRef.current.port.postMessage({ type: "flush" })
+        } catch (caught) {
+          console.warn("Failed to request microphone worklet flush", caught)
+          pendingFlushResolverRef.current?.()
+          pendingFlushResolverRef.current = null
+        }
+
+        await flushPromise
+      } finally {
+        cleanup()
+      }
+      return
+    }
+
     cleanup()
-  }, [cleanup])
+  }, [cleanup, clearFlushTimeout])
 
   const start = useCallback(async () => {
     if (!isSupported) {
@@ -163,63 +282,137 @@ export function useMicrophoneStream(options: UseMicrophoneStreamOptions = {}): U
       if (audioContext.state === "suspended") {
         await audioContext.resume().catch(() => undefined)
       }
+
       setSampleRate(audioContext.sampleRate)
 
-      const source = audioContext.createMediaStreamSource(stream)
-      const processor = audioContext.createScriptProcessor(bufferSize, 1, 1)
-      const gainNode = audioContext.createGain()
-      gainNode.gain.value = 0
+      const sourceNode = audioContext.createMediaStreamSource(stream)
+      sourceNodeRef.current = sourceNode
 
-      source.connect(processor)
-      processor.connect(gainNode)
-      gainNode.connect(audioContext.destination)
+      let workletInitialised = false
+      const supportsWorklet =
+        typeof AudioWorkletNode === "function" &&
+        !!audioContext.audioWorklet &&
+        typeof audioContext.audioWorklet.addModule === "function"
 
-      processor.onaudioprocess = (event) => {
-        const channelData = event.inputBuffer.getChannelData(0)
-        const frame = new Float32Array(channelData.length)
-        frame.set(channelData)
+      if (supportsWorklet) {
+        try {
+          const win = window as NextWindow
+          const prefix = win.__NEXT_DATA__?.assetPrefix?.replace(/\/$/, "") ?? ""
+          const moduleUrl = prefix ? `${prefix}${WORKLET_MODULE_PATH}` : WORKLET_MODULE_PATH
+          await audioContext.audioWorklet.addModule(moduleUrl)
 
-        const metadata: MicrophoneFrameMetadata = {
-          sampleRate: audioContext.sampleRate,
-          timestamp: performance.now(),
-        }
+          const workletNode = new AudioWorkletNode(audioContext, "microphone-worklet", {
+            processorOptions: {
+              bufferSize,
+              channelIndex: 0,
+            },
+          })
 
-        frameCallbackRef.current?.(frame, metadata)
+          workletNode.port.onmessage = (event) => {
+            const message = event.data as
+              | { type: "audio"; frame: Float32Array | ArrayBuffer; timestamp?: number }
+              | { type: "flush-complete" }
+              | undefined
 
-        let sum = 0
-        for (let i = 0; i < frame.length; i += 1) {
-          const value = frame[i]
-          sum += value * value
-        }
-        const rms = Math.sqrt(sum / frame.length)
-        const previous = volumeRef.current
-        const nextVolume = smoothing * previous + (1 - smoothing) * rms
-        volumeRef.current = nextVolume
-        if (Math.abs(nextVolume - previous) > 0.01) {
-          setVolume(nextVolume)
-          volumeCallbackRef.current?.(nextVolume)
+            if (!message) {
+              return
+            }
+
+            if (message.type === "audio") {
+              const frameData = message.frame
+              const frame =
+                frameData instanceof Float32Array ? frameData : new Float32Array(frameData)
+              const timestamp =
+                typeof message.timestamp === "number" ? message.timestamp * 1000 : undefined
+              processAudioFrame(frame, audioContext.sampleRate, timestamp)
+              return
+            }
+
+            if (message.type === "flush-complete") {
+              clearFlushTimeout()
+              const resolve = pendingFlushResolverRef.current
+              pendingFlushResolverRef.current = null
+              resolve?.()
+            }
+          }
+
+          workletNode.onprocessorerror = (caught) => {
+            console.error("Microphone worklet error", caught)
+            setError("Microphone processing failed. Please restart the session.")
+          }
+
+          const gainNode = audioContext.createGain()
+          gainNode.gain.value = 0
+          gainNodeRef.current = gainNode
+
+          sourceNode.connect(workletNode)
+          workletNode.connect(gainNode)
+          gainNode.connect(audioContext.destination)
+
+          workletRef.current = workletNode
+          workletInitialised = true
+        } catch (caught) {
+          console.warn("Falling back to ScriptProcessor microphone capture", caught)
         }
       }
 
-      processorRef.current = processor
-      gainRef.current = gainNode
+      if (!workletInitialised) {
+        const processor = audioContext.createScriptProcessor(bufferSize, 1, 1)
+        processor.onaudioprocess = (event) => {
+          const channelData = event.inputBuffer.getChannelData(0)
+          const frame = new Float32Array(channelData.length)
+          frame.set(channelData)
+          processAudioFrame(frame, audioContext.sampleRate)
+        }
+
+        const gainNode = audioContext.createGain()
+        gainNode.gain.value = 0
+        gainNodeRef.current = gainNode
+
+        sourceNode.connect(processor)
+        processor.connect(gainNode)
+        gainNode.connect(audioContext.destination)
+
+        scriptProcessorRef.current = processor
+      } else {
+        scriptProcessorRef.current = null
+      }
+
       setIsActive(true)
 
-      return { stream, sampleRate: audioContext.sampleRate }
+      return {
+        stream,
+        sampleRate: audioContext.sampleRate,
+      }
     } catch (caught) {
       console.error("Failed to start microphone stream", caught)
       cleanup()
       if (caught instanceof DOMException && caught.name === "NotAllowedError") {
         setPermission("denied")
         setError("Microphone access was denied")
+      } else if (caught instanceof DOMException && caught.name === "NotFoundError") {
+        setPermission("denied")
+        setError("No microphone was found. Check your device and try again.")
       } else {
         setError(caught instanceof Error ? caught.message : "Unable to access microphone")
       }
       throw caught
     }
-  }, [cleanup, isSupported, options.audioConstraints, bufferSize, smoothing])
+  }, [
+    cleanup,
+    clearFlushTimeout,
+    isSupported,
+    options.audioConstraints,
+    processAudioFrame,
+    bufferSize,
+  ])
 
-  useEffect(() => () => stop(), [stop])
+  useEffect(
+    () => () => {
+      void stop()
+    },
+    [stop],
+  )
 
   return {
     start,
@@ -233,4 +426,3 @@ export function useMicrophoneStream(options: UseMicrophoneStreamOptions = {}): U
     stream: streamRef.current,
   }
 }
-

--- a/public/audio-worklets/microphone-processor.js
+++ b/public/audio-worklets/microphone-processor.js
@@ -1,0 +1,95 @@
+// This AudioWorklet mirrors the low-latency buffer dispatch pattern used by
+// TarteelAI's `react-native-microphone-stream` module. It accumulates PCM frames
+// inside the audio rendering thread, then posts transferable chunks back to the
+// main UI thread so we can forward them to live tajweed inference services with
+// minimal delay.
+
+class MicrophoneWorkletProcessor extends AudioWorkletProcessor {
+  constructor(options) {
+    super()
+    const processorOptions = options?.processorOptions ?? {}
+    this.bufferSize = Math.max(128, Number(processorOptions.bufferSize) || 1024)
+    this.channelIndex = Number(processorOptions.channelIndex) || 0
+    this.frameBuffer = new Float32Array(this.bufferSize)
+    this.offset = 0
+
+    this.port.onmessage = (event) => {
+      if (!event?.data) {
+        return
+      }
+      if (event.data.type === "flush") {
+        this.flush(event.data.force)
+      }
+    }
+  }
+
+  flush(force = false) {
+    if (this.offset === 0 && !force) {
+      this.port.postMessage({ type: "flush-complete" })
+      return
+    }
+
+    const length = force ? this.frameBuffer.length : this.offset
+    if (length === 0) {
+      this.port.postMessage({ type: "flush-complete" })
+      return
+    }
+
+    const payload = new Float32Array(length)
+    payload.set(this.frameBuffer.subarray(0, length))
+
+    this.port.postMessage(
+      {
+        type: "audio",
+        frame: payload,
+        timestamp: currentTime,
+        partial: length !== this.frameBuffer.length,
+      },
+      [payload.buffer],
+    )
+
+    this.frameBuffer = new Float32Array(this.bufferSize)
+    this.offset = 0
+    this.port.postMessage({ type: "flush-complete" })
+  }
+
+  process(inputs) {
+    const input = inputs[0]
+    if (!input || input.length === 0) {
+      return true
+    }
+
+    const channel = input[this.channelIndex] ?? input[0]
+    if (!channel) {
+      return true
+    }
+
+    let index = 0
+    while (index < channel.length) {
+      const remaining = this.bufferSize - this.offset
+      const copyLength = Math.min(remaining, channel.length - index)
+      this.frameBuffer.set(channel.subarray(index, index + copyLength), this.offset)
+      this.offset += copyLength
+      index += copyLength
+
+      if (this.offset >= this.bufferSize) {
+        const frame = this.frameBuffer
+        this.port.postMessage(
+          {
+            type: "audio",
+            frame,
+            timestamp: currentTime,
+            partial: false,
+          },
+          [frame.buffer],
+        )
+        this.frameBuffer = new Float32Array(this.bufferSize)
+        this.offset = 0
+      }
+    }
+
+    return true
+  }
+}
+
+registerProcessor("microphone-worklet", MicrophoneWorkletProcessor)


### PR DESCRIPTION
## Summary
- add a dedicated audio-worklet that mimics the react-native microphone stream ring buffer for low-latency PCM delivery on the web
- overhaul `useMicrophoneStream` to load the worklet when available, expose async stop semantics with flush handshakes, and fall back to a script processor when necessary
- update live tajweed components to await the new stream lifecycle, preserve UI state, and avoid unhandled promises when starting or stopping analysis

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5146c776883279608aab8078088fd