### PR TITLE
Improve Mushaf typography spacing and highlights

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -155,7 +155,30 @@
     line-height: 2.8;
     font-feature-settings: "liga" 1, "dlig" 1, "kern" 1, "mark" 1, "mkmk" 1;
     text-rendering: optimizeLegibility;
-    letter-spacing: 0.015em;
+    letter-spacing: normal;
+  }
+
+  .mushaf-word {
+    display: inline-flex;
+    align-items: baseline;
+    position: relative;
+    transition: color 150ms ease, background-color 150ms ease, box-shadow 150ms ease;
+    padding-inline: 0.05em;
+    padding-block: 0.05em;
+    margin-inline-end: 0.35em;
+  }
+
+  .mushaf-word:last-of-type {
+    margin-inline-end: 0;
+  }
+
+  .mushaf-word[data-highlighted="true"] {
+    padding-inline: 0.25em;
+    padding-block: 0.1em;
+    border-radius: 0.5em;
+    background-color: var(--mushaf-highlight-bg, rgba(248, 113, 113, 0.18));
+    box-shadow: 0 0 0 1px var(--mushaf-highlight-border, rgba(248, 113, 113, 0.6));
+    color: var(--mushaf-highlight-text, inherit);
   }
 
   /* RTL layout utilities */

--- a/components/arabic-text.tsx
+++ b/components/arabic-text.tsx
@@ -5,8 +5,9 @@ import type React from "react"
 import { cn } from "@/lib/utils"
 import { forwardRef } from "react"
 
-interface ArabicTextProps extends React.HTMLAttributes<HTMLDivElement> {
-  variant?: "quran" | "modern" | "traditional"
+interface ArabicTextProps extends React.HTMLAttributes<HTMLElement> {
+  as?: "div" | "p" | "span"
+  variant?: "quran" | "modern" | "traditional" | "mushaf"
   size?: "sm" | "base" | "lg" | "xl" | "2xl" | "3xl" | "responsive"
   diacritics?: boolean
   animate?: boolean
@@ -14,9 +15,10 @@ interface ArabicTextProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode
 }
 
-const ArabicText = forwardRef<HTMLDivElement, ArabicTextProps>(
+const ArabicText = forwardRef<HTMLElement, ArabicTextProps>(
   (
     {
+      as = "div",
       className,
       variant = "traditional",
       size = "base",
@@ -34,6 +36,7 @@ const ArabicText = forwardRef<HTMLDivElement, ArabicTextProps>(
       quran: "font-quran",
       modern: "font-arabic-modern",
       traditional: "font-arabic",
+      mushaf: "font-mushaf",
     }
 
     const sizeClasses = {
@@ -50,8 +53,10 @@ const ArabicText = forwardRef<HTMLDivElement, ArabicTextProps>(
     const animateClass = animate ? "arabic-fade-in" : ""
     const highlightClass = highlight ? "arabic-highlight" : ""
 
+    const Component = as
+
     return (
-      <div
+      <Component
         ref={ref}
         className={cn(
           baseClasses,
@@ -65,7 +70,7 @@ const ArabicText = forwardRef<HTMLDivElement, ArabicTextProps>(
         {...props}
       >
         {children}
-      </div>
+      </Component>
     )
   },
 )


### PR DESCRIPTION
## Summary
- allow the reusable ArabicText component to render Mushaf typography and custom elements for consistent Quran text styling
- refactor the MushafVerse renderer to use ArabicText and CSS variable driven highlights so words keep natural spacing without overlay artifacts
- tune global Mushaf font metrics and introduce a `.mushaf-word` utility for steadier glyph spacing and tajweed highlights

## Testing
- npm run lint *(fails due to existing unrelated lint errors in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e53e51656883278ec6eff069b2cd88