### PR TITLE
Fix Recitation QA watcher metrics

### DIFF
--- a/app/api/integrations/tarteel-ml/route.ts
+++ b/app/api/integrations/tarteel-ml/route.ts
@@ -180,6 +180,8 @@ export async function GET() {
         pushed_at: string | null
         updated_at: string | null
         has_wiki: boolean
+        subscribers_count?: number
+        watchers?: number
       }>(`${GITHUB_API_BASE}`),
       fetchJson<Array<{ name: string; path: string; download_url?: string | null; size?: number | null }>>(
         `${GITHUB_API_BASE}/contents`,
@@ -208,7 +210,7 @@ export async function GET() {
         name: repo.name,
         description: repo.description,
         stars: repo.stargazers_count,
-        watchers: repo.watchers_count,
+        watchers: repo.subscribers_count ?? repo.watchers_count ?? repo.watchers,
         forks: repo.forks_count,
         openIssues: repo.open_issues_count,
         defaultBranch: repo.default_branch,


### PR DESCRIPTION
## Summary
- pull GitHub repository metadata for the Tarteel ML integration with subscriber counts
- fall back to watchers_count/watchers if subscriber data is unavailable so the Recitation QA card always renders a value

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5930a01ec8327b5d528a6e15c3786