### PR TITLE
Fix Quran reader recitation handler initialization order

### DIFF
--- a/app/reader/page.tsx
+++ b/app/reader/page.tsx
@@ -993,76 +993,6 @@ export default function QuranReaderPage() {
     }
   }
 
-  const handleNextAyah = useCallback(() => {
-    if (totalAyahs === 0) {
-      return
-    }
-
-    handleReciteAyah()
-  }, [handleReciteAyah, totalAyahs])
-
-  const handlePrevAyah = () => {
-    if (currentAyah > 0) {
-      setCurrentAyah(currentAyah - 1)
-      setIsPlaying(false)
-    }
-  }
-
-  const handleGwaniPlayPause = async () => {
-    const audio = gwaniAudioRef.current
-    if (!audio) {
-      return
-    }
-
-    if (isGwaniPlaying) {
-      audio.pause()
-      return
-    }
-
-    try {
-      setGwaniError(null)
-      if (audio.readyState < 2) {
-        setIsGwaniLoading(true)
-      }
-      await audio.play()
-    } catch (error) {
-      console.error("Failed to start Gwani Dahir audio", error)
-      setIsGwaniPlaying(false)
-      setIsGwaniLoading(false)
-      setGwaniError("Playback was blocked. Tap play again or try another moment.")
-    }
-  }
-
-  const handleGwaniProgressChange = (value: number[]) => {
-    const audio = gwaniAudioRef.current
-    if (!audio || !Number.isFinite(gwaniDuration) || gwaniDuration <= 0) {
-      return
-    }
-
-    const [nextTime] = value
-    if (!Number.isFinite(nextTime)) {
-      return
-    }
-
-    const clampedTime = Math.min(Math.max(nextTime, 0), gwaniDuration)
-    audio.currentTime = clampedTime
-    setGwaniCurrentTime(clampedTime)
-  }
-
-  const handleSyncReaderWithGwani = () => {
-    setSelectedSurah(gwaniSelectedSurah)
-    setCurrentAyah(0)
-    setIsPlaying(false)
-    if (typeof window !== "undefined") {
-      window.scrollTo({ top: 0, behavior: "smooth" })
-    }
-  }
-
-  const handleAyahClick = (index: number) => {
-    setCurrentAyah(index)
-    setIsPlaying(false)
-  }
-
   const handleReciteAyah = useCallback(() => {
     if (!activeAyah) {
       return
@@ -1132,6 +1062,76 @@ export default function QuranReaderPage() {
     surahData.metadata.number,
     totalAyahs,
   ])
+
+  const handleNextAyah = useCallback(() => {
+    if (totalAyahs === 0) {
+      return
+    }
+
+    handleReciteAyah()
+  }, [handleReciteAyah, totalAyahs])
+
+  const handlePrevAyah = () => {
+    if (currentAyah > 0) {
+      setCurrentAyah(currentAyah - 1)
+      setIsPlaying(false)
+    }
+  }
+
+  const handleGwaniPlayPause = async () => {
+    const audio = gwaniAudioRef.current
+    if (!audio) {
+      return
+    }
+
+    if (isGwaniPlaying) {
+      audio.pause()
+      return
+    }
+
+    try {
+      setGwaniError(null)
+      if (audio.readyState < 2) {
+        setIsGwaniLoading(true)
+      }
+      await audio.play()
+    } catch (error) {
+      console.error("Failed to start Gwani Dahir audio", error)
+      setIsGwaniPlaying(false)
+      setIsGwaniLoading(false)
+      setGwaniError("Playback was blocked. Tap play again or try another moment.")
+    }
+  }
+
+  const handleGwaniProgressChange = (value: number[]) => {
+    const audio = gwaniAudioRef.current
+    if (!audio || !Number.isFinite(gwaniDuration) || gwaniDuration <= 0) {
+      return
+    }
+
+    const [nextTime] = value
+    if (!Number.isFinite(nextTime)) {
+      return
+    }
+
+    const clampedTime = Math.min(Math.max(nextTime, 0), gwaniDuration)
+    audio.currentTime = clampedTime
+    setGwaniCurrentTime(clampedTime)
+  }
+
+  const handleSyncReaderWithGwani = () => {
+    setSelectedSurah(gwaniSelectedSurah)
+    setCurrentAyah(0)
+    setIsPlaying(false)
+    if (typeof window !== "undefined") {
+      window.scrollTo({ top: 0, behavior: "smooth" })
+    }
+  }
+
+  const handleAyahClick = (index: number) => {
+    setCurrentAyah(index)
+    setIsPlaying(false)
+  }
 
   useEffect(() => {
     if (challengeStatus !== "cracked") {


### PR DESCRIPTION
## Summary
- move the recitation handler declaration above its first usage to avoid temporal dead zone errors
- keep the ayah navigation callbacks intact after relocating the handler

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b73fc06c83278ffc5b63ae1c3ad3