### PR TITLE
Add logout support to navigation

### DIFF
--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react"
 import Link from "next/link"
-import { usePathname } from "next/navigation"
+import { usePathname, useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { useUser } from "@/hooks/use-user"
@@ -29,7 +29,8 @@ import {
 export default function Navigation() {
   const [isOpen, setIsOpen] = useState(false)
   const pathname = usePathname()
-  const { profile, isPremium } = useUser()
+  const router = useRouter()
+  const { profile, isPremium, signOut } = useUser()
 
   const navigation = [
     { name: "Dashboard", href: "/dashboard", icon: Home },
@@ -190,7 +191,9 @@ export default function Navigation() {
               className="w-full justify-start text-gray-700 bg-transparent"
               onClick={() => {
                 console.log("[v0] User logging out")
-                // In a real implementation, this would handle logout
+                signOut()
+                setIsOpen(false)
+                router.push("/auth/login")
               }}
             >
               <LogOut className="h-4 w-4 mr-2" />

--- a/components/user-provider.tsx
+++ b/components/user-provider.tsx
@@ -34,7 +34,7 @@ import {
   type QuranReaderRecitationInput,
   type QuranReaderRecitationResult,
 } from "@/lib/data/teacher-database"
-import { getActiveSession } from "@/lib/data/auth"
+import { getActiveSession, signOut as clearActiveSession } from "@/lib/data/auth"
 
 export type UserProfile = LearnerProfile
 export type UserStats = LearnerStats
@@ -67,6 +67,7 @@ interface UserContextValue {
   reviewMemorizationTask: (review: MemorizationReviewInput) => void
   completeDailySurahRecitation: (completion: DailySurahCompletionInput) => DailySurahCompletionResult
   recordQuranReaderProgress: (recitation: QuranReaderRecitationInput) => QuranReaderRecitationResult
+  signOut: () => void
 }
 
 const perksByPlan: Record<SubscriptionPlan, string[]> = {
@@ -454,6 +455,24 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     [applyLearnerState, studentId],
   )
 
+  const handleSignOut = useCallback(() => {
+    clearActiveSession()
+    setProfile({
+      id: studentId,
+      name: "Guest Learner",
+      email: "guest@alfawz.app",
+      role: "student",
+      locale: "en-US",
+      plan: "free",
+      joinedAt: new Date().toISOString(),
+    })
+    setStats(createEmptyStats())
+    setHabits([])
+    setDashboard(sanitizeDashboardRecord(createFallbackDashboardRecord(studentId)))
+    setTeachers([])
+    setError(null)
+  }, [studentId])
+
   const completeRecitationAssignment = useCallback(
     (taskId: string) => {
       const task = dashboard?.recitationTasks.find((entry) => entry.id === taskId)
@@ -554,6 +573,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
       recordQuranReaderProgress,
       upgradeToPremium,
       downgradeToFree,
+      signOut: handleSignOut,
     }),
     [
       profile,
@@ -581,6 +601,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
       recordQuranReaderProgress,
       upgradeToPremium,
       downgradeToFree,
+      handleSignOut,
     ],
   )
 


### PR DESCRIPTION
## Summary
- add a sign-out handler to the user provider that clears the active session and resets local state
- update the navigation sign-out button to invoke the handler and redirect to the login screen

## Testing
- npm run lint *(fails: existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e6442435e083278da153faebcfd13f